### PR TITLE
Engine singleton

### DIFF
--- a/.yardopts
+++ b/.yardopts
@@ -1,1 +1,1 @@
-lib/**/*.rb - README.md LICENSE.txt CODE_OF_CONDUCT.md
+--no-private --markup markdown lib/**/*.rb - README.md LICENSE.txt CODE_OF_CONDUCT.md

--- a/lib/zenaton/client.rb
+++ b/lib/zenaton/client.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module Zenaton
+  # Zenaton Client
+  class Client
+    # Start the specified workflow
+    # @param workflow [Zenaton::Workflow]
+    def start_workflow(workflow); end
+  end
+end

--- a/lib/zenaton/engine.rb
+++ b/lib/zenaton/engine.rb
@@ -1,28 +1,72 @@
 # frozen_string_literal: true
 
 require 'singleton'
+require 'zenaton/exceptions'
+require 'zenaton/task'
+require 'zenaton/workflow'
+require 'zenaton/client'
+require 'zenaton/processor'
 
 module Zenaton
-  # :nodoc:
+  # Zenaton Engine is a singleton class that stores a reference to the current
+  # client and processor. It then handles job processing either locally or
+  # through the processor with Zenaton workers
+  # To access the instance, call `Zenaton::Engine.instance`
   class Engine
     include Singleton
 
+    # @param value [Zenaton::Processor]
     attr_writer :processor
 
+    # @private
     def initialize
-      @client = nil
+      @client = Zenaton::Client.new
       @processor = nil
     end
 
-    def execute(jobs = [])
+    # Executes jobs synchronously
+    # @param jobs [Array<Zenaton::Job>]
+    # @return [Array<String>, nil] the results if executed locally, or nil
+    def execute(jobs)
+      jobs.map(&method(:check_argument))
       return jobs.map(&:handle) if process_locally?(jobs)
       @processor.process(jobs, true)
+    end
+
+    # Executes jobs asynchronously
+    # @param jobs [Array<Zenaton::Job>]
+    # @return nil
+    def dispatch(jobs)
+      jobs.map(&method(:check_argument))
+      jobs.map(&method(:local_dispatch)) if process_locally?(jobs)
+      @processor&.process(jobs, false) unless jobs.length.zero?
+      nil
     end
 
     private
 
     def process_locally?(jobs)
       jobs.length.zero? || @processor.nil?
+    end
+
+    def local_dispatch(job)
+      if job.is_a? Zenaton::Workflow
+        @client.start_workflow(job)
+      else
+        job.handle
+      end
+    end
+
+    def check_argument(job)
+      raise InvalidArgumentError, error_message unless valid_job?(job)
+    end
+
+    def error_message
+      'You can only execute or dispatch Zenaton Task or Worflow'
+    end
+
+    def valid_job?(job)
+      job.is_a?(Zenaton::Task) || job.is_a?(Zenaton::Workflow)
     end
   end
 end

--- a/lib/zenaton/exceptions.rb
+++ b/lib/zenaton/exceptions.rb
@@ -18,4 +18,7 @@ module Zenaton
 
   # Exception raised when network connectivity is lost
   class ConnectionError < Error; end
+
+  # Exception raised when interfaces are not fulfilled by client code
+  class NotImplemented < Error; end
 end

--- a/lib/zenaton/job.rb
+++ b/lib/zenaton/job.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'zenaton/exceptions'
+
+module Zenaton
+  # Base class for jobs. Zenaton tasks and workflows inherit from this class.
+  class Job
+    # Child classes should implement the handle method
+    def handle
+      raise NotImplemented, "Your job does not implement the `handle' method"
+    end
+  end
+end

--- a/lib/zenaton/processor.rb
+++ b/lib/zenaton/processor.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Zenaton
+  # Zenaton Processor
+  class Processor
+    # processes the jobs
+    # @param jobs [Array<Zenaton::Job>]
+    # @param bool [Boolean]
+    def process(jobs, bool); end
+  end
+end

--- a/lib/zenaton/task.rb
+++ b/lib/zenaton/task.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require 'zenaton/job'
+
+module Zenaton
+  # Base class for Tasks. Your tasks should inherit from this class
+  class Task < Job
+    # Child classes should implement the handle method
+    def handle
+      raise NotImplemented,
+            "Your workflow does not implement the `handle' method"
+    end
+  end
+end

--- a/lib/zenaton/workflow.rb
+++ b/lib/zenaton/workflow.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require 'zenaton/job'
+
+module Zenaton
+  # Base class for Workflows. Your workflows should inherit from this class
+  class Workflow < Job
+    # Child classes should implement the handle method
+    def handle
+      raise NotImplemented,
+            "Your workflow does not implement the `handle' method"
+    end
+  end
+end

--- a/spec/zenaton/engine_spec.rb
+++ b/spec/zenaton/engine_spec.rb
@@ -4,8 +4,31 @@ require 'zenaton/engine'
 
 RSpec.describe Zenaton::Engine do
   let(:engine) { described_class.instance }
+  let(:processor) do
+    instance_double(Zenaton::Processor, process: nil)
+  end
+  let(:client) do
+    instance_double(Zenaton::Client, start_workflow: nil)
+  end
+  let(:task) do
+    instance_double(
+      Zenaton::Task,
+      handle: 'result1'
+    )
+  end
+  let(:workflow) do
+    instance_double(
+      Zenaton::Workflow,
+      handle: 'result2'
+    )
+  end
+  let(:invalid_job) { Object.new }
 
-  before { Singleton.__init__(described_class) }
+  before do
+    setup_engine
+    setup_task_double
+    setup_worflow_double
+  end
 
   describe 'initialization' do
     it 'is a singleton class' do
@@ -25,18 +48,27 @@ RSpec.describe Zenaton::Engine do
     it 'sets the processor to nil' do
       expect(engine.instance_variable_get(:@processor)).to be_nil
     end
+
+    it 'initializes a new client' do
+      expect(engine.instance_variable_get(:@client)).to eq(client)
+    end
   end
 
   describe '#processor=' do
     it 'can store a processor' do
-      engine.processor = 'this should be a processor'
+      engine.processor = processor
       expect(engine.instance_variable_get(:@processor)).to \
-        eq('this should be a processor')
+        eq(processor)
     end
   end
 
   describe '#execute' do
-    let(:processor) { double(process: nil) }
+    context 'when using invalid jobs' do
+      it 'raise an invalid argument error' do
+        expect { engine.execute([invalid_job]) }.to \
+          raise_error Zenaton::InvalidArgumentError
+      end
+    end
 
     context 'when there are no processor nor jobs to process' do
       let(:results) { engine.execute([]) }
@@ -53,9 +85,7 @@ RSpec.describe Zenaton::Engine do
     end
 
     context 'when there are no processor but jobs to process' do
-      let(:job1) { double(handle: 'result1') }
-      let(:job2) { double(handle: 'result2') }
-      let(:results) { engine.execute([job1, job2]) }
+      let(:results) { engine.execute([task, workflow]) }
 
       before { results }
 
@@ -67,8 +97,12 @@ RSpec.describe Zenaton::Engine do
         expect(processor).not_to have_received(:process)
       end
 
-      it 'sends `handle` to each job' do
-        expect(job1).to have_received(:handle).with(no_args)
+      it 'sends `handle` to tasks' do
+        expect(task).to have_received(:handle).with(no_args)
+      end
+
+      it 'sends `handle` to workflows' do
+        expect(workflow).to have_received(:handle).with(no_args)
       end
     end
 
@@ -90,9 +124,7 @@ RSpec.describe Zenaton::Engine do
     end
 
     context 'when there is a  processor and jobs to process' do
-      let(:job1) { double(handle: 'result1') }
-      let(:job2) { double(handle: 'result2') }
-      let(:results) { engine.execute([job1, job2]) }
+      let(:results) { engine.execute([task, workflow]) }
 
       before do
         engine.processor = processor
@@ -104,18 +136,112 @@ RSpec.describe Zenaton::Engine do
       end
 
       it 'tells the processor to process' do
-        expect(processor).to have_received(:process).with([job1, job2], true)
+        expect(processor).to \
+          have_received(:process).with([task, workflow], true)
       end
 
-      it 'does not send `handle` to each job' do
-        expect(job1).not_to have_received(:handle)
+      it 'does not send `handle` to tasks' do
+        expect(task).not_to have_received(:handle)
+      end
+
+      it 'does not send `handle` to workflows' do
+        expect(workflow).not_to have_received(:handle)
       end
     end
   end
 
   describe '#dispatch' do
-    it 'responds to dispatch' do
-      expect(engine).to respond_to(:dispatch)
+    context 'when using invalid jobs' do
+      it 'raise an invalid argument error' do
+        expect { engine.execute([invalid_job]) }.to \
+          raise_error Zenaton::InvalidArgumentError
+      end
     end
+
+    context 'when there is no processor and no jobs' do
+      let(:results) { engine.dispatch([]) }
+
+      before { results }
+
+      it 'returns nothing' do
+        expect(results).to be_nil
+      end
+    end
+
+    context 'when there is a processor but no jobs' do
+      let(:results) { engine.dispatch([]) }
+
+      before do
+        engine.processor = processor
+        results
+      end
+
+      it 'returns nothing' do
+        expect(results).to be_nil
+      end
+
+      it 'does not tell the processor to process' do
+        expect(processor).not_to have_received(:process)
+      end
+    end
+
+    context 'when there is no processor but there are jobs' do
+      let(:results) { engine.dispatch([task, workflow]) }
+
+      before { results }
+
+      it 'returns nothing' do
+        expect(results).to be_nil
+      end
+
+      it 'calls handle on task' do
+        expect(task).to have_received(:handle).with(no_args)
+      end
+
+      it 'sends workflows to the client' do
+        expect(client).to have_received(:start_workflow).with(workflow)
+      end
+    end
+
+    context 'when there is a processor and jobs' do
+      let(:results) { engine.dispatch([task, workflow]) }
+
+      before do
+        engine.processor = processor
+        results
+      end
+
+      it 'returns nothing' do
+        expect(results).to be_nil
+      end
+
+      it 'does not call handle on jobs' do
+        expect(task).not_to have_received(:handle)
+      end
+
+      it 'does not send workflows to the client' do
+        expect(client).not_to have_received(:start_workflow)
+      end
+
+      it 'send the jobs to the processor' do
+        expect(processor).to \
+          have_received(:process).with([task, workflow], false)
+      end
+    end
+  end
+
+  def setup_engine
+    Singleton.__init__(described_class)
+    allow(Zenaton::Client).to receive(:new).and_return(client)
+  end
+
+  def setup_task_double
+    allow(task).to receive(:is_a?).with(Zenaton::Workflow).and_return(false)
+    allow(task).to receive(:is_a?).with(Zenaton::Task).and_return(true)
+  end
+
+  def setup_worflow_double
+    allow(workflow).to receive(:is_a?).with(Zenaton::Task).and_return(false)
+    allow(workflow).to receive(:is_a?).with(Zenaton::Workflow).and_return(true)
   end
 end

--- a/spec/zenaton/job_spec.rb
+++ b/spec/zenaton/job_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'zenaton/job'
+
+RSpec.describe Zenaton::Job do
+  let(:job) { described_class.new }
+
+  describe '#handle' do
+    it 'raises a not implemented error' do
+      expect { job.handle }.to raise_error Zenaton::NotImplemented
+    end
+  end
+end

--- a/spec/zenaton/task_spec.rb
+++ b/spec/zenaton/task_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'zenaton/task'
+
+RSpec.describe Zenaton::Task do
+  let(:task) { described_class.new }
+
+  describe '#handle' do
+    it 'raises a not implemented error' do
+      expect { task.handle }.to raise_error Zenaton::NotImplemented
+    end
+  end
+end

--- a/spec/zenaton/workflow_spec.rb
+++ b/spec/zenaton/workflow_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'zenaton/workflow'
+
+RSpec.describe Zenaton::Workflow do
+  let(:flow) { described_class.new }
+
+  describe '#handle' do
+    it 'raises a not implemented error' do
+      expect { flow.handle }.to raise_error Zenaton::NotImplemented
+    end
+  end
+end


### PR DESCRIPTION
Reimplements the Engine singleton. Taken from the php library.

Only significant change from the php library is the lack of interfaces in Ruby. The workaround consists of using class inheritance and raising an error in methods we expect to be defined in children classes.