### PR TITLE
Fix serializer converting to json

### DIFF
--- a/lib/zenaton/services/serializer.rb
+++ b/lib/zenaton/services/serializer.rb
@@ -38,7 +38,7 @@ module Zenaton
           value[KEY_OBJECT] = encode_object(data)
         end
         value[KEY_STORE] = @encoded
-        value.to_json
+        value
       end
 
       # Decodes Zenaton's format in a valid Ruby object

--- a/spec/zenaton/client_spec.rb
+++ b/spec/zenaton/client_spec.rb
@@ -150,7 +150,7 @@ RSpec.describe Zenaton::Client do
         'programming_language' => 'Ruby',
         'canonical_name' => nil,
         'name' => 'FakeWorkflow1',
-        'data' => '{"a":{"@first":1,"@second":2},"s":[]}',
+        'data' => { 'a' => { :@first => 1, :@second => 2 }, 's' => [] },
         'custom_id' => nil
       }
     end
@@ -312,7 +312,7 @@ RSpec.describe Zenaton::Client do
         'name' => 'MyWorkflow',
         'custom_id' => 'MyCustomId',
         'event_name' => 'FakeEvent',
-        'event_input' => '{"a":{},"s":[]}'
+        'event_input' => { 'a' => {}, 's' => [] }
       }
     end
 

--- a/spec/zenaton/services/serializer_spec.rb
+++ b/spec/zenaton/services/serializer_spec.rb
@@ -8,13 +8,12 @@ RSpec.describe Zenaton::Services::Serializer do
 
   describe '#encode' do
     let(:encoded) { serializer.encode(data) }
-    let(:parsed_json) { JSON.parse(encoded) }
 
     context 'with a string' do
       let(:data) { 'e' }
 
       it 'represents the string as a data' do
-        expect(parsed_json).to eq('d' => 'e', 's' => [])
+        expect(encoded).to eq('d' => 'e', 's' => [])
       end
     end
 
@@ -22,7 +21,7 @@ RSpec.describe Zenaton::Services::Serializer do
       let(:data) { 1 }
 
       it 'represents the integer as a data' do
-        expect(parsed_json).to eq('d' => 1, 's' => [])
+        expect(encoded).to eq('d' => 1, 's' => [])
       end
     end
 
@@ -30,7 +29,7 @@ RSpec.describe Zenaton::Services::Serializer do
       let(:data) { 1.8 }
 
       it 'represents the float as a data' do
-        expect(parsed_json).to eq('d' => 1.8, 's' => [])
+        expect(encoded).to eq('d' => 1.8, 's' => [])
       end
     end
 
@@ -38,7 +37,7 @@ RSpec.describe Zenaton::Services::Serializer do
       let(:data) { true }
 
       it 'represents the boolean as a data' do
-        expect(parsed_json).to eq('d' => true, 's' => [])
+        expect(encoded).to eq('d' => true, 's' => [])
       end
     end
 
@@ -46,7 +45,7 @@ RSpec.describe Zenaton::Services::Serializer do
       let(:data) { false }
 
       it 'represents the boolean as a data' do
-        expect(parsed_json).to eq('d' => false, 's' => [])
+        expect(encoded).to eq('d' => false, 's' => [])
       end
     end
 
@@ -54,7 +53,7 @@ RSpec.describe Zenaton::Services::Serializer do
       let(:data) { nil }
 
       it 'represents the boolean as a data' do
-        expect(parsed_json).to eq('d' => nil, 's' => [])
+        expect(encoded).to eq('d' => nil, 's' => [])
       end
     end
 
@@ -62,7 +61,7 @@ RSpec.describe Zenaton::Services::Serializer do
       let(:data) { proc { |x| puts x } }
 
       it 'raises an exception' do
-        expect { parsed_json }.to raise_error ArgumentError
+        expect { encoded }.to raise_error ArgumentError
       end
     end
 
@@ -70,7 +69,7 @@ RSpec.describe Zenaton::Services::Serializer do
       let(:data) { [1, 'e'] }
 
       it 'represents the array as an array' do
-        expect(parsed_json).to eq('a' => [1, 'e'], 's' => [])
+        expect(encoded).to eq('a' => [1, 'e'], 's' => [])
       end
     end
 
@@ -78,7 +77,7 @@ RSpec.describe Zenaton::Services::Serializer do
       let(:data) { { 'key' => 'value' } }
 
       it 'represents the hash as an array' do
-        expect(parsed_json).to \
+        expect(encoded).to \
           eq('a' => { 'key' => 'value' }, 's' => [])
       end
     end
@@ -92,7 +91,7 @@ RSpec.describe Zenaton::Services::Serializer do
             {
               'n' => 'SerializeMe',
               'p' => {
-                '@initialized' => true
+                :@initialized => true
               }
             }
           ]
@@ -100,7 +99,7 @@ RSpec.describe Zenaton::Services::Serializer do
       end
 
       it 'represents the object as an object' do
-        expect(parsed_json).to eq(expected_representation)
+        expect(encoded).to eq(expected_representation)
       end
     end
 
@@ -113,12 +112,12 @@ RSpec.describe Zenaton::Services::Serializer do
             {
               'n' => 'SerializeCircular::Parent',
               'p' => {
-                '@child' => '@zenaton#1'
+                :@child => '@zenaton#1'
               }
             }, {
               'n' => 'SerializeCircular::Child',
               'p' => {
-                '@parent' => '@zenaton#0'
+                :@parent => '@zenaton#0'
               }
             }
           ]
@@ -126,7 +125,7 @@ RSpec.describe Zenaton::Services::Serializer do
       end
 
       it 'represents the object as an object' do
-        expect(parsed_json).to eq(expected_representation)
+        expect(encoded).to eq(expected_representation)
       end
     end
   end


### PR DESCRIPTION
The conversion from/to JSON is the responsability of the http class.
Remove JSON formatting from serializer to avoid passing properties as
strings instead of objects.