### PR TITLE
Handle allocation of Singleton classes

### DIFF
--- a/lib/zenaton/services/properties.rb
+++ b/lib/zenaton/services/properties.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'singleton'
+
 module Zenaton
   module Services
     # Wrapper class to read instance variables from an object and
@@ -9,7 +11,12 @@ module Zenaton
       # @param class_name [String] the name of the class to allocate
       # @return [Object]
       def blank_instance(class_name)
-        Object.const_get(class_name).allocate
+        klass = Object.const_get(class_name)
+        if klass < Singleton
+          klass.instance
+        else
+          klass.allocate
+        end
       end
 
       # Returns a hash with the instance variables of a given object

--- a/spec/fixtures/serialize_me.rb
+++ b/spec/fixtures/serialize_me.rb
@@ -1,8 +1,22 @@
 # frozen_string_literal: true
 
+require 'singleton'
+
 class SerializeMe
   def initialize
     @initialized = true
+  end
+
+  def initialized?
+    @initialized || false
+  end
+end
+
+class SerializeSingleton
+  include Singleton
+
+  def initialize
+    @intialized = true
   end
 
   def initialized?

--- a/spec/zenaton/services/properties_spec.rb
+++ b/spec/zenaton/services/properties_spec.rb
@@ -7,16 +7,32 @@ RSpec.describe Zenaton::Services::Properties do
   let(:properties) { described_class.new }
 
   describe '#blank_instance' do
-    let(:instance) do
-      properties.blank_instance('SerializeMe')
+    context 'with a regular class' do
+      let(:instance) do
+        properties.blank_instance('SerializeMe')
+      end
+
+      it 'creates a new instance of the provided class' do
+        expect(instance).to be_a(SerializeMe)
+      end
+
+      it 'does not call initialize when instantiating' do
+        expect(instance).not_to be_initialized
+      end
     end
 
-    it 'creates a new instance of the provided class' do
-      expect(instance).to be_a(SerializeMe)
-    end
+    context 'with a singleton class' do
+      let(:instance) do
+        properties.blank_instance('SerializeSingleton')
+      end
 
-    it 'does not call initialize when instantiating' do
-      expect(instance).not_to be_initialized
+      it 'fetches the instance of the provided class' do
+        expect(instance).to be_a(SerializeSingleton)
+      end
+
+      it 'does not call initialize when instantiating' do
+        expect(instance).not_to be_initialized
+      end
     end
   end
 
@@ -70,7 +86,7 @@ RSpec.describe Zenaton::Services::Properties do
     end
 
     it 'does not raise if object is an instance of superclass' do
-      expect { valid_object_with_superclass }.not_to raise_error ArgumentError
+      expect { valid_object_with_superclass }.not_to raise_error
     end
 
     it 'sets the given instance variables on the object' do


### PR DESCRIPTION
Singleton classes do not respond to allocate. We check if a given class
includes the Singleton module and call #instance instead of #allocate
when this is the case.