### PR TITLE
More types

### DIFF
--- a/lib/zenaton/services/properties.rb
+++ b/lib/zenaton/services/properties.rb
@@ -8,7 +8,13 @@ module Zenaton
     # to create new objects with a given set of instance variables.
     class Properties
       # Handle (de)serializaton separately for these classes.
-      SPECIAL_CASES = [Time, Date, DateTime, Rational].freeze
+      SPECIAL_CASES = [
+        Time,
+        Date,
+        DateTime,
+        Rational,
+        Complex
+      ].freeze
 
       # Returns an allocated instance of the given class name
       # @param class_name [String] the name of the class to allocate
@@ -17,8 +23,8 @@ module Zenaton
         klass = Object.const_get(class_name)
         if klass < Singleton
           klass.instance
-        elsif klass == Rational
-          Rational(1, 1)
+        elsif [Rational, Complex].include?(klass)
+          Kernel.send(klass.to_s, 1, 1)
         else
           klass.allocate
         end
@@ -81,6 +87,8 @@ module Zenaton
           from_date_time(object)
         when 'Rational'
           from_rational(object)
+        when 'Complex'
+          from_complex(object)
         end
       end
 
@@ -107,6 +115,10 @@ module Zenaton
         { 'n' => object.numerator, 'd' => object.denominator }
       end
 
+      def from_complex(object)
+        { 'r' => object.real, 'i' => object.imaginary }
+      end
+
       def set_complex_type(object, props)
         case object.class.name
         when 'Time'
@@ -117,6 +129,8 @@ module Zenaton
           return_date_time(props)
         when 'Rational'
           return_rational(props)
+        when 'Complex'
+          return_complex(props)
         end
       end
 
@@ -146,6 +160,10 @@ module Zenaton
 
       def return_rational(props)
         Rational(props['n'], props['d'])
+      end
+
+      def return_complex(props)
+        Complex(props['r'], props['i'])
       end
 
       def special_case?(object)

--- a/lib/zenaton/services/properties.rb
+++ b/lib/zenaton/services/properties.rb
@@ -8,7 +8,7 @@ module Zenaton
     # to create new objects with a given set of instance variables.
     class Properties
       # Handle (de)serializaton separately for these classes.
-      SPECIAL_CASES = [Time, Date, DateTime].freeze
+      SPECIAL_CASES = [Time, Date, DateTime, Rational].freeze
 
       # Returns an allocated instance of the given class name
       # @param class_name [String] the name of the class to allocate
@@ -17,6 +17,8 @@ module Zenaton
         klass = Object.const_get(class_name)
         if klass < Singleton
           klass.instance
+        elsif klass == Rational
+          Rational(1, 1)
         else
           klass.allocate
         end
@@ -77,6 +79,8 @@ module Zenaton
           from_date(object)
         when 'DateTime'
           from_date_time(object)
+        when 'Rational'
+          from_rational(object)
         end
       end
 
@@ -99,6 +103,10 @@ module Zenaton
         }
       end
 
+      def from_rational(object)
+        { 'n' => object.numerator, 'd' => object.denominator }
+      end
+
       def set_complex_type(object, props)
         case object.class.name
         when 'Time'
@@ -107,6 +115,8 @@ module Zenaton
           return_date(props)
         when 'DateTime'
           return_date_time(props)
+        when 'Rational'
+          return_rational(props)
         end
       end
 
@@ -132,6 +142,10 @@ module Zenaton
                 end
         args << props['sg']
         DateTime.civil(*args) # rubocop:disable Style/DateTime
+      end
+
+      def return_rational(props)
+        Rational(props['n'], props['d'])
       end
 
       def special_case?(object)

--- a/lib/zenaton/services/properties.rb
+++ b/lib/zenaton/services/properties.rb
@@ -1,6 +1,11 @@
 # frozen_string_literal: true
 
 require 'singleton'
+require 'json/add/core'
+require 'json/add/rational'
+require 'json/add/complex'
+require 'json/add/bigdecimal'
+require 'json/add/ostruct'
 
 module Zenaton
   module Services
@@ -9,22 +14,35 @@ module Zenaton
     class Properties
       # Handle (de)serializaton separately for these classes.
       SPECIAL_CASES = [
-        Time,
-        Date,
-        DateTime,
-        Rational,
-        Complex
-      ].freeze
+        ::Complex,
+        ::Date,
+        ::DateTime,
+        ::Range,
+        ::Rational,
+        ::Regexp,
+        ::Symbol,
+        ::Time,
+        defined?(::OpenStruct) ? ::OpenStruct : nil,
+        defined?(::BigDecimal) ? ::BigDecimal : nil
+      ].compact.freeze
+
+      NUMERIC_INITIALIATION = [
+        ::Rational,
+        ::Complex,
+        defined?(::BigDecimal) ? ::BigDecimal : nil
+      ].compact.freeze
 
       # Returns an allocated instance of the given class name
       # @param class_name [String] the name of the class to allocate
       # @return [Object]
       def blank_instance(class_name)
         klass = Object.const_get(class_name)
-        if klass < Singleton
+        if klass < ::Singleton
           klass.instance
-        elsif [Rational, Complex].include?(klass)
+        elsif NUMERIC_INITIALIATION.include?(klass)
           Kernel.send(klass.to_s, 1, 1)
+        elsif klass == Symbol
+          :place_holder
         else
           klass.allocate
         end
@@ -78,96 +96,20 @@ module Zenaton
       end
 
       def from_complex_type(object)
-        case object.class.name
-        when 'Time'
-          from_time(object)
-        when 'Date'
-          from_date(object)
-        when 'DateTime'
-          from_date_time(object)
-        when 'Rational'
-          from_rational(object)
-        when 'Complex'
-          from_complex(object)
+        JSON.parse(object.to_json).tap do |attributes|
+          attributes.delete('json_class')
         end
-      end
-
-      def from_time(object)
-        nanoseconds = [object.tv_usec * 1_000]
-        object.respond_to?(:tv_nsec) && nanoseconds << object.tv_nsec
-        { 's' => object.tv_sec, 'n' => nanoseconds.max }
-      end
-
-      def from_date(object)
-        { 'y' => object.year, 'm' => object.month,
-          'd' => object.day, 'sg' => object.start }
-      end
-
-      def from_date_time(object)
-        {
-          'y' => object.year, 'm' => object.month, 'd' => object.day,
-          'H' => object.hour, 'M' => object.minute, 'S' => object.sec,
-          'of' => object.offset.to_s, 'sg' => object.start
-        }
-      end
-
-      def from_rational(object)
-        { 'n' => object.numerator, 'd' => object.denominator }
-      end
-
-      def from_complex(object)
-        { 'r' => object.real, 'i' => object.imaginary }
       end
 
       def set_complex_type(object, props)
-        case object.class.name
-        when 'Time'
-          return_time(object, props)
-        when 'Date'
-          return_date(props)
-        when 'DateTime'
-          return_date_time(props)
-        when 'Rational'
-          return_rational(props)
-        when 'Complex'
-          return_complex(props)
-        end
-      end
-
-      def return_time(object, props)
-        if object.respond_to?(:tv_usec)
-          Time.at(props['s'], Rational(props['n'], 1000))
-        else
-          Time.at(props['s'], props['n'] / 1000)
-        end
-      end
-
-      def return_date(props)
-        Date.civil(*props.values_at('y', 'm', 'd', 'sg'))
-      end
-
-      def return_date_time(props)
-        args = props.values_at('y', 'm', 'd', 'H', 'M', 'S')
-        of_a, of_b = props['of'].split('/')
-        args << if of_b && of_b != 0
-                  Rational(of_a.to_i, of_b.to_i)
-                else
-                  of_a
-                end
-        args << props['sg']
-        DateTime.civil(*args) # rubocop:disable Style/DateTime
-      end
-
-      def return_rational(props)
-        Rational(props['n'], props['d'])
-      end
-
-      def return_complex(props)
-        Complex(props['r'], props['i'])
+        props['json_class'] = object.class.name
+        JSON(props.to_json)
       end
 
       def special_case?(object)
-        SPECIAL_CASES.include?(object.class)
+        SPECIAL_CASES.include?(object.class) \
+          || object.is_a?(Struct) \
+          || object.is_a?(Exception)
       end
     end
   end

--- a/spec/zenaton/services/properties_spec.rb
+++ b/spec/zenaton/services/properties_spec.rb
@@ -67,6 +67,14 @@ RSpec.describe Zenaton::Services::Properties do
       # rubocop:enable Style/DateTime
     end
 
+    context 'with rational numbers' do
+      let(:object) { 2 / 3r }
+
+      it 'returns the numerator and denominator' do
+        expect(result).to eq('n' => 2, 'd' => 3)
+      end
+    end
+
     context 'with other objects' do
       let(:object) { SerializeMe.new }
 
@@ -114,6 +122,15 @@ RSpec.describe Zenaton::Services::Properties do
         expect(setup_object).to eq(expected_date_time)
       end
       # rubocop:enable Style/DateTime
+    end
+
+    context 'with rational numbers' do
+      let(:object_name) { 'Rational' }
+      let(:props) { { 'n' => 2, 'd' => 3 } }
+
+      it 'sets the props correctly' do
+        expect(setup_object).to eq(2 / 3r)
+      end
     end
 
     context 'with other objects' do

--- a/spec/zenaton/services/properties_spec.rb
+++ b/spec/zenaton/services/properties_spec.rb
@@ -83,6 +83,64 @@ RSpec.describe Zenaton::Services::Properties do
       end
     end
 
+    context 'with big decimals' do
+      let(:object) { BigDecimal(1, 1) }
+
+      it 'returns the decimal dump' do
+        expect(result).to eq('b' => '27:0.1e1')
+      end
+    end
+
+    context 'with open structs' do
+      let(:object) { OpenStruct.new(a: 1) }
+
+      it 'returns the struct instance variables table' do
+        expect(result).to eq('t' => { 'a' => 1 })
+      end
+    end
+
+    context 'with symbols' do
+      let(:object) { :hello }
+
+      it 'returns the symbols as a string' do
+        expect(result).to eq('s' => 'hello')
+      end
+    end
+
+    context 'with ranges' do
+      let(:object) { 1..5 }
+
+      it 'returns the range delimiters' do
+        expect(result).to eq('a' => [1, 5, false])
+      end
+    end
+
+    context 'with regular expressions' do
+      let(:object) { /[a-z]/i }
+
+      it 'returns the range delimiters' do
+        expect(result).to eq('o' => 1, 's' => '[a-z]')
+      end
+    end
+
+    context 'with structs' do
+      let(:object) { Struct::Customer.new('bob') }
+
+      before { Struct.new('Customer', :name) }
+
+      it 'returns the object values' do
+        expect(result).to eq('v' => ['bob'])
+      end
+    end
+
+    context 'with exceptions' do
+      let(:object) { StandardError.new('oops') }
+
+      it 'returns the error message and the backtrace' do
+        expect(result).to eq('m' => 'oops', 'b' => nil)
+      end
+    end
+
     context 'with other objects' do
       let(:object) { SerializeMe.new }
 
@@ -150,6 +208,79 @@ RSpec.describe Zenaton::Services::Properties do
       end
     end
 
+    context 'with big decimals' do
+      let(:object_name) { 'BigDecimal' }
+      let(:props) { { 'b' => '27:0.1e1' } }
+
+      it 'parses the dump' do
+        expect(setup_object).to eq(BigDecimal(1, 1))
+      end
+    end
+
+    context 'with open structs' do
+      let(:object_name) { 'OpenStruct' }
+      let(:props) { { 't' => { 'a' => 1 } } }
+
+      it 'returns an open struct' do
+        expect(setup_object).to be_an(OpenStruct)
+      end
+
+      it 'has the expected methods' do
+        expect(setup_object.a).to eq(1)
+      end
+    end
+
+    context 'with symbols' do
+      let(:object_name) { 'Symbol' }
+      let(:props) { { 's' => 'hello' } }
+
+      it 'returns a symbol version of the string' do
+        expect(setup_object).to eq(:hello)
+      end
+    end
+
+    context 'with ranges' do
+      let(:object_name) { 'Range' }
+      let(:props) { { 'a' => [1, 5, false] } }
+
+      it 'returns the range' do
+        expect(setup_object).to eq(1..5)
+      end
+    end
+
+    context 'with regular expressions' do
+      let(:object_name) { 'Regexp' }
+      let(:props) { { 'o' => 1, 's' => '[a-z]' } }
+
+      it 'returns correct regular expression' do
+        expect(setup_object).to eq(/[a-z]/i)
+      end
+    end
+
+    context 'with structs' do
+      let(:object_name) { 'Struct::Customer' }
+      let(:props) { { 'v' => ['bob'] } }
+
+      before { Struct.new('Customer', :name) }
+
+      it 'rebuilds the struct' do
+        expect(setup_object.name).to eq('bob')
+      end
+    end
+
+    context 'with exceptions' do
+      let(:object_name) { 'StandardError' }
+      let(:props) { { 'm' => 'oops', 'b' => nil } }
+
+      it 'preserves the exception message' do
+        expect(setup_object.message).to eq('oops')
+      end
+
+      it 'preserves the exception backtrace' do
+        expect(setup_object.backtrace).to be_nil
+      end
+    end
+
     context 'with other objects' do
       let(:object_name) { 'SerializeMe' }
       let(:props) { { :@initialized => true } }
@@ -197,8 +328,7 @@ RSpec.describe Zenaton::Services::Properties do
     end
 
     it 'sets the given instance variables on the object' do
-      expect(valid_object.instance_variable_get(:@initialized)).to \
-        eq(true)
+      expect(valid_object.instance_variable_get(:@initialized)).to eq(true)
     end
   end
 end

--- a/spec/zenaton/services/properties_spec.rb
+++ b/spec/zenaton/services/properties_spec.rb
@@ -75,6 +75,14 @@ RSpec.describe Zenaton::Services::Properties do
       end
     end
 
+    context 'with complex numbers' do
+      let(:object) { 1 + 2i }
+
+      it 'returns the numerator and denominator' do
+        expect(result).to eq('r' => 1, 'i' => 2)
+      end
+    end
+
     context 'with other objects' do
       let(:object) { SerializeMe.new }
 
@@ -130,6 +138,15 @@ RSpec.describe Zenaton::Services::Properties do
 
       it 'sets the props correctly' do
         expect(setup_object).to eq(2 / 3r)
+      end
+    end
+
+    context 'with complex numbers' do
+      let(:object_name) { 'Complex' }
+      let(:props) { { 'r' => 1, 'i' => 2 } }
+
+      it 'returns the complex number' do
+        expect(setup_object).to eq(1 + 2i)
       end
     end
 

--- a/spec/zenaton/services/properties_spec.rb
+++ b/spec/zenaton/services/properties_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe Zenaton::Services::Properties do
       let(:object) { BigDecimal(1, 1) }
 
       it 'returns the decimal dump' do
-        expect(result).to eq('b' => '27:0.1e1')
+        expect(result['b'].downcase).to eq('27:0.1e1')
       end
     end
 


### PR DESCRIPTION
Adding serialization for the same classes supported by the json library. Namely
- Complex numbers
- Rational numbers
- Big decimals
- Symbols
- Ranges
- Regular expressions
- Structs and OpenStructs

Refactored existing serialization of time objects to rely on the json library instead of reimplementing it. 