### PR TITLE
Fix circular empty array

### DIFF
--- a/lib/zenaton/services/serializer.rb
+++ b/lib/zenaton/services/serializer.rb
@@ -75,7 +75,7 @@ module Zenaton
       end
 
       def encode_to_store(object)
-        id = @decoded.index(object)
+        id = @decoded.index { |decoded| decoded.object_id == object.object_id }
         return store_id(id) if id
         store_and_encode(object)
       end

--- a/spec/zenaton/services/serializer_spec.rb
+++ b/spec/zenaton/services/serializer_spec.rb
@@ -157,6 +157,31 @@ RSpec.describe Zenaton::Services::Serializer do
       end
     end
 
+    context 'with empty arrays' do
+      let(:array1) { [] }
+      let(:array2) { [] }
+      let(:data) { array1 }
+      let(:expected_representation) do
+        {
+          'o' => '@zenaton#0',
+          's' => [{
+            'a' => ['@zenaton#1']
+          }, {
+            'a' => ['@zenaton#0']
+          }]
+        }
+      end
+
+      before do
+        array1 << array2
+        array2 << array1
+      end
+
+      it 'represents the two empty arrays as distinct objects' do
+        expect(parsed_json).to eq(expected_representation)
+      end
+    end
+
     context 'with a hash' do
       let(:data) { { 'key' => 'value' } }
       let(:expected_representation) do
@@ -202,6 +227,31 @@ RSpec.describe Zenaton::Services::Serializer do
       end
 
       it 'represents the hash as an object' do
+        expect(parsed_json).to eq(expected_representation)
+      end
+    end
+
+    context 'with empty circular hashes' do
+      let(:hash1) { {} }
+      let(:hash2) { {} }
+      let(:data) { hash1 }
+      let(:expected_representation) do
+        {
+          'o' => '@zenaton#0',
+          's' => [{
+            'a' => { 'foo' => '@zenaton#1' }
+          }, {
+            'a' => { 'foo' => '@zenaton#0' }
+          }]
+        }
+      end
+
+      before do
+        hash1[:foo] = hash2
+        hash2[:foo] = hash1
+      end
+
+      it 'represents the two empty hashes as distinct objects' do
         expect(parsed_json).to eq(expected_representation)
       end
     end

--- a/spec/zenaton/services/serializer_spec.rb
+++ b/spec/zenaton/services/serializer_spec.rb
@@ -465,6 +465,31 @@ RSpec.describe Zenaton::Services::Serializer do
       end
     end
 
+    context 'with a empty circular arrays' do
+      let(:json) do
+        {
+          'o' => '@zenaton#0',
+          's' => [{
+            'a' => ['@zenaton#1']
+          }, {
+            'a' => ['@zenaton#0']
+          }]
+        }.to_json
+      end
+
+      it 'returns an array' do
+        expect(decoded).to be_a(Array)
+      end
+
+      it 'has correct circular structure' do
+        expect(decoded[-1][-1]).to be(decoded)
+      end
+
+      it 'distinguishes between children' do
+        expect(decoded[-1]).not_to be(decoded)
+      end
+    end
+
     context 'with a new hash format' do
       let(:json) do
         {
@@ -489,6 +514,35 @@ RSpec.describe Zenaton::Services::Serializer do
 
       it 'has correct circular structure' do
         expect(decoded['child']['parent']).to eq(decoded)
+      end
+    end
+
+    context 'with empty circular hashes' do
+      let(:json) do
+        {
+          'o' => '@zenaton#0',
+          's' => [{
+            'a' => {
+              'foo' => '@zenaton#1'
+            }
+          }, {
+            'a' => {
+              'foo' => '@zenaton#0'
+            }
+          }]
+        }.to_json
+      end
+
+      it 'returns a hash' do
+        expect(decoded).to be_a(Hash)
+      end
+
+      it 'has correct circular structure' do
+        expect(decoded['foo']['foo']).to be(decoded)
+      end
+
+      it 'distinguishes between the children' do
+        expect(decoded['foo']).not_to be(decoded)
       end
     end
 


### PR DESCRIPTION
In the case where
```ruby
array1 = []
array2 = []
array1 << array2
array2 << array1
```

Then `array1 == array2` would be `true`, which led to the serializer
assigning only one id.

The fix involves using `array1.object_id == array2.object_id` to make sure
a given index matches one object and not other objects that may be equal
to itself.