### PR TITLE
Parse json error body from api response

### DIFF
--- a/lib/zenaton/services/http.rb
+++ b/lib/zenaton/services/http.rb
@@ -94,7 +94,8 @@ module Zenaton
       end
 
       def format_error(response)
-        "#{response.code}: #{response.message}"
+        message = JSON.parse(response.read_body)['error']
+        "#{response.code}: #{message}"
       end
 
       def default_options

--- a/spec/zenaton/services/http_spec.rb
+++ b/spec/zenaton/services/http_spec.rb
@@ -38,9 +38,8 @@ RSpec.describe Zenaton::Services::Http do
         VCR.use_cassette('get_request_404') { example.run }
       end
 
-      it 'raises an internal error' do
-        expect { request }.to \
-          raise_error Zenaton::InternalError, '404: Not Found'
+      it 'raises an internal error with parsed body as message' do
+        expect { request }.to raise_error Zenaton::InternalError, '404: '
       end
     end
 
@@ -95,9 +94,8 @@ RSpec.describe Zenaton::Services::Http do
         VCR.use_cassette('post_request_404') { example.run }
       end
 
-      it 'raises an internal error' do
-        expect { request }.to \
-          raise_error Zenaton::InternalError, '404: Not Found'
+      it 'raises an internal error with parsed body as message' do
+        expect { request }.to raise_error Zenaton::InternalError, '404: '
       end
     end
 
@@ -154,9 +152,8 @@ RSpec.describe Zenaton::Services::Http do
         VCR.use_cassette('put_request_404') { example.run }
       end
 
-      it 'raises an internal error' do
-        expect { request }.to \
-          raise_error Zenaton::InternalError, '404: Not Found'
+      it 'raises an internal error with parsed body as message' do
+        expect { request }.to raise_error Zenaton::InternalError, '404: '
       end
     end
 


### PR DESCRIPTION
The agent's API returns an error message in the body of the error
response. Parse it and return it so it can be used by the CLI