### PR TITLE
Rename on_day method to day_of_month

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Changed
+- Rename `on_day` method to `day_of_month`
 - Improve error messages by using the message containerd in the API response when
 available.
 

--- a/lib/zenaton/traits/with_timestamp.rb
+++ b/lib/zenaton/traits/with_timestamp.rb
@@ -37,7 +37,7 @@ module Zenaton
       end
 
       %i[
-        timestamp at on_day monday tuesday wednesday thursday
+        timestamp at day_of_month monday tuesday wednesday thursday
         friday saturday sunday
       ]. each do |method_name|
         define_method method_name do |value = 1|
@@ -56,8 +56,8 @@ module Zenaton
           _timestamp(value)
         elsif method == :at
           _at(value, now, now_dup)
-        elsif method == :on_day
-          _on_day(value, now, now_dup)
+        elsif method == :day_of_month
+          _day_of_month(value, now, now_dup)
         else
           _apply_duration(method, value, now_dup)
         end
@@ -96,7 +96,7 @@ module Zenaton
         end
       end
 
-      def _on_day(day, now, now_dup)
+      def _day_of_month(day, now, now_dup)
         _set_mode(MODE_MONTH_DAY)
         now_dup = now_dup.change(day: day)
         now_dup += 1.month if now > now_dup

--- a/spec/shared_examples/with_timestamp.rb
+++ b/spec/shared_examples/with_timestamp.rb
@@ -74,7 +74,7 @@ RSpec.shared_examples 'WithTimestamp' do |*initial_args|
     context 'when specifying a day of the month' do
       let(:expected_time) { Time.utc(2018, 8, 12, 12, 2, 0) }
 
-      before { with_timestamp.on_day(12) }
+      before { with_timestamp.day_of_month(12) }
 
       it { is_expected.to eq([expected_time.to_i, nil]) }
     end
@@ -146,7 +146,7 @@ RSpec.shared_examples 'WithTimestamp' do |*initial_args|
     context 'when specifying next 12th at 6PM' do
       let(:expected_time) { Time.utc(2018, 8, 12, 18, 0, 0) }
 
-      before { with_timestamp.on_day(12).at('18') }
+      before { with_timestamp.day_of_month(12).at('18') }
 
       it { is_expected.to eq([expected_time.to_i, nil]) }
     end
@@ -224,7 +224,7 @@ RSpec.shared_examples 'WithTimestamp' do |*initial_args|
 
       before do
         expected_time
-        with_timestamp.on_day(12)
+        with_timestamp.day_of_month(12)
       end
 
       it { is_expected.to eq([expected_time.to_i, nil]) }
@@ -323,7 +323,7 @@ RSpec.shared_examples 'WithTimestamp' do |*initial_args|
 
       before do
         expected_time
-        with_timestamp.on_day(12).at('18')
+        with_timestamp.day_of_month(12).at('18')
       end
 
       it { is_expected.to eq [expected_time.to_i, nil] }


### PR DESCRIPTION
While this is a rather small change and only needed because we want to keep similar syntax in all languages we currently support, this is effectively a breaking change.

Next release version should see a major version bump.