### PR TITLE
Rescue from error when find non existing workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Changed
 - Rename `on_day` method to `day_of_month`
-- Improve error messages by using the message containerd in the API response when
+- Improve error messages by using the message contained in the API response when
 available.
+- Rescue from new engine error when finding non existing workflow
 
 ## [0.2.3] - 2018-08-13
 ### Added

--- a/lib/zenaton/client.rb
+++ b/lib/zenaton/client.rb
@@ -120,17 +120,18 @@ module Zenaton
 
     # Finds a workflow
     # @param workflow_name [String] the class name of the workflow
-    # @param custom_id [String] the custom ID of the workflow (if any)
-    # @return [Zenaton::Interfaces::Workflow]
+    # @param custom_id [String] the custom ID of the workflow
+    # @return [Zenaton::Interfaces::Workflow, nil]
     def find_workflow(workflow_name, custom_id)
-      # rubocop:disable Metrics/LineLength
-      params = "#{ATTR_ID}=#{custom_id}&#{ATTR_NAME}=#{workflow_name}&#{ATTR_PROG}=#{PROG}"
-      # rubocop:enable Metrics/LineLength
+      params = "#{ATTR_ID}=#{custom_id}&#{ATTR_NAME}=#{workflow_name}&#{ATTR_PROG}=#{PROG}" # rubocop:disable Metrics/LineLength
       data = @http.get(instance_website_url(params))['data']
       data && @properties.object_from(
         data['name'],
         @serializer.decode(data['properties'])
       )
+    rescue Zenaton::InternalError => exception
+      return nil if exception.message =~ /No workflow instance found/
+      raise exception
     end
 
     # Sends an event to a workflow

--- a/spec/zenaton/client_spec.rb
+++ b/spec/zenaton/client_spec.rb
@@ -283,15 +283,14 @@ RSpec.describe Zenaton::Client do
       client.find_workflow('FakeWorkflow1', 'MyCustomId')
     end
 
-    before do
-      described_class.init(nil, 'ApiToken', nil)
-      allow(http).to receive(:get)
-        .with(expected_url)
-        .and_return(sample_response)
-      result
-    end
-
     context 'when there is a matching workflow' do
+      before do
+        described_class.init(nil, 'ApiToken', nil)
+        allow(http).to receive(:get)
+          .with(expected_url)
+          .and_return(sample_response)
+      end
+
       let(:sample_response) do
         {
           'data' => {
@@ -315,12 +314,29 @@ RSpec.describe Zenaton::Client do
     end
 
     context 'when there is no matching workflow' do
-      let(:sample_response) do
-        { 'error' => 'No workflow instance found with the id : 2' }
+      before do
+        described_class.init(nil, 'ApiToken', nil)
+        allow(http).to receive(:get)
+          .with(expected_url)
+          .and_raise(Zenaton::InternalError,
+                     '404: No workflow instance found with the id : MyCustomId')
       end
 
-      it 'returns nil ' do
+      it 'returns nil' do
         expect(result).to be_nil
+      end
+    end
+
+    context 'when another exception is raised' do
+      before do
+        described_class.init(nil, 'ApiToken', nil)
+        allow(http).to receive(:get)
+          .with(expected_url)
+          .and_raise(Zenaton::InternalError, 'Oopsies')
+      end
+
+      it 'raises the exception' do
+        expect { result }.to raise_error Zenaton::InternalError, 'Oopsies'
       end
     end
   end


### PR DESCRIPTION
The engine response has changed. Before when trying to fetch a non
existing workflow, it would respond with a 200 and a message saying the
requested workflow was not found. Now it returns a 404. While this is
semantincally more correct, our http module treats anything with a HTTP
status code greater than 400 as an error and converts the error to a
Zenaton internal error. This in turn blocks us from rescueing from a
specific error when doing the actual call, so we now check the message
instead. If the message corresponds to a workflow not being found, we
return `nil` as before. If not we re raise the exception.