### PR TITLE
Fix serialization error with ActiveModel object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- [Serialization]: Serializing ActiveModel object should no longer raise an
+  error
 
 ## [0.3.0] - 2018-09-24
 ### Changed
@@ -23,7 +26,7 @@ available.
 ## [0.2.2] - 2018-08-10
 ### Fixed
 - [Serialization]: Distinct objects, even if equal to one another, now map to
-distinct entries in the data store.
+  distinct entries in the data store.
 
 ## [0.2.1] - 2018-08-10
 ### Added
@@ -36,11 +39,11 @@ distinct entries in the data store.
 ## [0.2.0] - 2018-08-08
 ### Added
 - New serialization format for array and hashes. Currently running workflows
-should still be able to deserialize data in the old format.
+  should still be able to deserialize data in the old format.
 
 ### Fixed
 - Arrays and hashes with circular structures no longer cause infinite loops when
-serializing.
+  serializing.
 
 ## [0.1.1] - 2018-08-03
 ### Added

--- a/lib/zenaton/services/serializer.rb
+++ b/lib/zenaton/services/serializer.rb
@@ -60,8 +60,8 @@ module Zenaton
         data.is_a?(String) \
           || data.is_a?(Integer) \
           || data.is_a?(Float) \
-          || data == true \
-          || data == false \
+          || data.is_a?(TrueClass) \
+          || data.is_a?(FalseClass) \
           || data.nil?
       end
 

--- a/spec/fixtures/fake_active_model.rb
+++ b/spec/fixtures/fake_active_model.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class FakeActiveModel
+  # https://github.com/rails/rails/blob/master/activemodel/lib/active_model/attribute_set.rb
+
+  def initialize(attributes)
+    @attributes = attributes
+  end
+
+  def ==(other)
+    attributes == other.attributes
+  end
+
+  protected
+
+  attr_reader :attributes
+end

--- a/spec/zenaton/services/serializer_spec.rb
+++ b/spec/zenaton/services/serializer_spec.rb
@@ -2,6 +2,7 @@
 
 require 'zenaton/services/serializer'
 require 'fixtures/serialize_me'
+require 'fixtures/fake_active_model'
 
 RSpec.describe Zenaton::Services::Serializer do
   let(:serializer) { described_class.new }
@@ -300,6 +301,15 @@ RSpec.describe Zenaton::Services::Serializer do
 
       it 'represents the object as an object' do
         expect(parsed_json).to eq(expected_representation)
+      end
+    end
+
+    context 'with an object that overrides ==' do
+      let(:data) { FakeActiveModel.new(name: 'Bob') }
+
+      it 'does not raise error' do
+        expect { parsed_json }.not_to \
+          raise_error NoMethodError
       end
     end
   end


### PR DESCRIPTION
When checking if an object is true or false using `==` raised an error
with ActiveModel objects. AM definition of `==`
https://github.com/rails/rails/blob/master/activemodel/lib/active_model/attribute_set.rb#L100
assumes the other object being compared is also an AM object and calls
`#attributes` on it. It is not rare to override the `#==(other)` method
so let's use `is_a?` instead.