### PR TITLE
Implement dispatch of tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Calling `#dispatch` on tasks now allows to process tasks asynchronously
 
 ## [0.3.1] - 2018-10-02
 ### Fixed

--- a/lib/zenaton/client.rb
+++ b/lib/zenaton/client.rb
@@ -81,6 +81,17 @@ module Zenaton
       add_app_env(url, params)
     end
 
+    # Start a single task
+    # @param task [Zenaton::Interfaces::Task]
+    def start_task(task)
+      @http.post(
+        worker_url('tasks'),
+        ATTR_PROG => PROG,
+        ATTR_NAME => class_name(task),
+        ATTR_DATA => @serializer.encode(@properties.from(task))
+      )
+    end
+
     # Start the specified workflow
     # @param flow [Zenaton::Interfaces::Workflow]
     def start_workflow(flow)

--- a/lib/zenaton/client.rb
+++ b/lib/zenaton/client.rb
@@ -28,6 +28,8 @@ module Zenaton
     ATTR_DATA = 'data' # Parameter name for json payload
     ATTR_PROG = 'programming_language' # Parameter name for the language
     ATTR_MODE = 'mode' # Parameter name for the worker update mode
+    # Parameter name for task maximum processing time
+    ATTR_MAX_PROCESSING_TIME = 'maxProcessingTime'
 
     PROG = 'Ruby' # The current programming language
 
@@ -84,11 +86,15 @@ module Zenaton
     # Start a single task
     # @param task [Zenaton::Interfaces::Task]
     def start_task(task)
+      max_processing_time = if task.respond_to?(:max_processing_time)
+                              task.max_processing_time
+                            end
       @http.post(
         worker_url('tasks'),
         ATTR_PROG => PROG,
         ATTR_NAME => class_name(task),
-        ATTR_DATA => @serializer.encode(@properties.from(task))
+        ATTR_DATA => @serializer.encode(@properties.from(task)),
+        ATTR_MAX_PROCESSING_TIME => max_processing_time
       )
     end
 

--- a/lib/zenaton/engine.rb
+++ b/lib/zenaton/engine.rb
@@ -53,7 +53,7 @@ module Zenaton
       if job.is_a? Interfaces::Workflow
         @client.start_workflow(job)
       else
-        job.handle
+        @client.start_task(job)
       end
     end
 

--- a/spec/fixtures/tasks.rb
+++ b/spec/fixtures/tasks.rb
@@ -13,3 +13,14 @@ class FakeTask2 < Zenaton::Interfaces::Task
     'result2'
   end
 end
+
+class FakeTask3 < Zenaton::Interfaces::Task
+  def initialize(arg1, arg2)
+    @arg1 = arg1
+    @arg2 = arg2
+  end
+
+  def handle
+    'result3'
+  end
+end

--- a/spec/zenaton/client_spec.rb
+++ b/spec/zenaton/client_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe Zenaton::Client do
     )
   end
   let(:workflow) { FakeWorkflow1.new(1, 2) }
+  let(:task) { FakeTask3.new(1, 2) }
   let(:event) { FakeEvent.new }
   let(:version) { FakeVersion.new(1, 2) }
   let(:workflow_data) { { 'name' => 'Zenaton::Interfaces::Workflow' } }
@@ -138,6 +139,28 @@ RSpec.describe Zenaton::Client do
         expect(url).to \
           eq('https://zenaton.com/api/v1/my_resource?api_token=ApiToken&app_env=AppEnv&app_id=AppId&myParam=1')
       end
+    end
+  end
+
+  describe '#start_task' do
+    let(:start_task) { client.start_task(task) }
+    let(:expected_url) { 'http://localhost:4001/api/v_newton/tasks?' }
+    let(:expected_hash) do
+      {
+        'programming_language' => 'Ruby',
+        'name' => 'FakeTask3',
+        'data' => {
+          'o' => '@zenaton#0',
+          's' => [{ 'a' => { :@arg1 => 1, :@arg2 => 2 } }]
+        }.to_json
+      }
+    end
+
+    before { start_task }
+
+    it 'sends the serialized task to the worker' do
+      expect(http).to have_received(:post)
+        .with(expected_url, expected_hash)
     end
   end
 

--- a/spec/zenaton/client_spec.rb
+++ b/spec/zenaton/client_spec.rb
@@ -149,6 +149,7 @@ RSpec.describe Zenaton::Client do
       {
         'programming_language' => 'Ruby',
         'name' => 'FakeTask3',
+        'maxProcessingTime' => nil,
         'data' => {
           'o' => '@zenaton#0',
           's' => [{ 'a' => { :@arg1 => 1, :@arg2 => 2 } }]

--- a/spec/zenaton/engine_spec.rb
+++ b/spec/zenaton/engine_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Zenaton::Engine do
     instance_double(Zenaton::Processor, process: nil)
   end
   let(:client) do
-    instance_double(Zenaton::Client, start_workflow: nil)
+    instance_double(Zenaton::Client, start_workflow: nil, start_task: nil)
   end
   let(:task) { FakeTask1.new }
   let(:workflow) { FakeWorkflow1.new(1, 2) }
@@ -169,6 +169,10 @@ RSpec.describe Zenaton::Engine do
         expect(results).to be_nil
       end
 
+      it 'sends tasks to the client' do
+        expect(client).to have_received(:start_task).with(task)
+      end
+
       it 'sends workflows to the client' do
         expect(client).to have_received(:start_workflow).with(workflow)
       end
@@ -184,6 +188,10 @@ RSpec.describe Zenaton::Engine do
 
       it 'returns nothing' do
         expect(results).to be_nil
+      end
+
+      it 'does not send tasks to the client' do
+        expect(client).not_to have_received(:start_task).with(task)
       end
 
       it 'does not send workflows to the client' do


### PR DESCRIPTION
Tasks that are not part of a workflow can now be directly dispatched to be processed asynchronously

Closes https://github.com/zenaton/zenaton-ruby/issues/45