### PR TITLE
Fix waiting for later today

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -16,5 +16,10 @@ Metrics/ClassLength:
     - 'lib/zenaton/client.rb'
     - 'lib/zenaton/services/serializer.rb'
 
+Metrics/ModuleLength:
+  Enabled: true
+  Exclude:
+    - 'lib/zenaton/traits/with_timestamp.rb'
+
 Style/NumericLiterals:
   Enabled: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changes
 - Update Zenaton engine URL to point to the new subdomain.
 
+### Fixed
+- When creating a `Wait` task which uses both `#at` (to specify time) and either
+  `#day_of_month` or `#monday` et al (to set day), it was surprising that the
+  wait task only waited for next week/month when it would make sense to wait for
+  later the same day. For example, on a Monday at 1 p.m, it waits for a couple
+  of hours if you create a wait task with `.monday(1).at("15")`. Otherwise the
+  previous behaviour of waiting for next week is preserved.
+
 ## [0.3.1] - 2018-10-02
 ### Fixed
 - [Serialization]: Serializing ActiveModel object should no longer raise an

--- a/spec/shared_examples/with_timestamp.rb
+++ b/spec/shared_examples/with_timestamp.rb
@@ -329,4 +329,73 @@ RSpec.shared_examples 'WithTimestamp' do |*initial_args|
       it { is_expected.to eq [expected_time.to_i, nil] }
     end
   end
+
+  context 'when today is Monday the 3rd of December 2012, at 11am' do
+    let(:today) { Time.utc(2018, 12, 3, 11, 0, 0) }
+    let(:timestamp) { with_timestamp._get_timestamp_or_duration.first }
+
+    before { Timecop.freeze(today) }
+
+    after { Timecop.return }
+
+    context 'when waiting for next Monday' do
+      let(:expected_time) { Time.utc(2018, 12, 10, 11, 0, 0) }
+
+      before { with_timestamp.monday(1) }
+
+      it 'waits until next week' do
+        expect(timestamp).to eq(expected_time.to_i)
+      end
+    end
+
+    context 'when waiting for next Monday at 1pm' do
+      let(:expected_time) { Time.utc(2018, 12, 3, 13, 0, 0) }
+
+      before { with_timestamp.monday(1).at('13') }
+
+      it 'waits until later today' do
+        expect(timestamp).to eq(expected_time.to_i)
+      end
+    end
+
+    context 'when waiting for the next Monday at 9am' do
+      let(:expected_time) { Time.utc(2018, 12, 10, 9, 0, 0) }
+
+      before { with_timestamp.monday(1).at('9') }
+
+      it 'waits until next week' do
+        expect(timestamp).to eq(expected_time.to_i)
+      end
+    end
+
+    context 'when waiting for next 3rd of the month' do
+      let(:expected_time) { Time.utc(2019, 1, 3, 11, 0, 0) }
+
+      before { with_timestamp.day_of_month(3) }
+
+      it 'waits until next month' do
+        expect(timestamp).to eq(expected_time.to_i)
+      end
+    end
+
+    context 'when waiting for next 3rd of the month at 1pm' do
+      let(:expected_time) { Time.utc(2018, 12, 3, 13, 0, 0) }
+
+      before { with_timestamp.day_of_month(3).at('13') }
+
+      it 'waits until later today' do
+        expect(timestamp).to eq(expected_time.to_i)
+      end
+    end
+
+    context 'when waiting for next 3rd of the month at 9am' do
+      let(:expected_time) { Time.utc(2019, 1, 3, 9, 0, 0) }
+
+      before { with_timestamp.day_of_month(3).at('9') }
+
+      it 'waits until next month' do
+        expect(timestamp).to eq(expected_time.to_i)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Fixes and closes https://github.com/zenaton/zenaton-ruby/issues/46

If we are on Monday, 11am on the 23rd of the month. Then:

`.monday(1)` should wait until next Monday at 11am
`.monday(1).at("9")` should wait until next Monday at 9am
`.monday(1).at("13")` should wait 2 hours only
`.day_of_Month(23)` should wait for one month
`.day_of_month(23).at("13")` should wait for only 2 hours