### PR TITLE
Update zenaton engine url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - Calling `#dispatch` on tasks now allows to process tasks asynchronously
 
+### Changes
+- Update Zenaton engine URL to point to the new subdomain.
+
 ## [0.3.1] - 2018-10-02
 ### Fixed
 - [Serialization]: Serializing ActiveModel object should no longer raise an

--- a/lib/zenaton/client.rb
+++ b/lib/zenaton/client.rb
@@ -11,7 +11,7 @@ module Zenaton
   class Client
     include Singleton
 
-    ZENATON_API_URL = 'https://zenaton.com/api/v1' # Zenaton api url
+    ZENATON_API_URL = 'https://api.zenaton.com/api/v1' # Zenaton api url
     ZENATON_WORKER_URL = 'http://localhost' # Default worker url
     DEFAULT_WORKER_PORT = 4001 # Default worker port
     WORKER_API_VERSION = 'v_newton' # Default worker api version

--- a/spec/zenaton/client_spec.rb
+++ b/spec/zenaton/client_spec.rb
@@ -137,7 +137,7 @@ RSpec.describe Zenaton::Client do
       it 'returns the default website url with params and api token' do
         url = client.website_url('my_resource', 'myParam=1')
         expect(url).to \
-          eq('https://zenaton.com/api/v1/my_resource?api_token=ApiToken&app_env=AppEnv&app_id=AppId&myParam=1')
+          eq('https://api.zenaton.com/api/v1/my_resource?api_token=ApiToken&app_env=AppEnv&app_id=AppId&myParam=1')
       end
     end
   end
@@ -301,7 +301,7 @@ RSpec.describe Zenaton::Client do
 
   describe '#find_workflow' do
     let(:expected_url) do
-      'https://zenaton.com/api/v1/instances?api_token=ApiToken&custom_id=MyCustomId&name=FakeWorkflow1&programming_language=Ruby'
+      'https://api.zenaton.com/api/v1/instances?api_token=ApiToken&custom_id=MyCustomId&name=FakeWorkflow1&programming_language=Ruby'
     end
     let(:result) do
       client.find_workflow('FakeWorkflow1', 'MyCustomId')


### PR DESCRIPTION
The Zenaton API now lives on a dedicated subdomain. This PR updates the client code to point to the new url.