### PR TITLE
Url encode query params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   later the same day. For example, on a Monday at 1 p.m, it waits for a couple
   of hours if you create a wait task with `.monday(1).at("15")`. Otherwise the
   previous behaviour of waiting for next week is preserved.
+- Fix encoding of query parameters when searching for existing workflows
 
 ## [0.3.1] - 2018-10-02
 ### Fixed

--- a/lib/zenaton/client.rb
+++ b/lib/zenaton/client.rb
@@ -141,7 +141,8 @@ module Zenaton
     # @param custom_id [String] the custom ID of the workflow
     # @return [Zenaton::Interfaces::Workflow, nil]
     def find_workflow(workflow_name, custom_id)
-      params = { ATTR_ID => custom_id, ATTR_NAME => workflow_name, ATTR_PROG => PROG }
+      params = { ATTR_ID => custom_id, ATTR_NAME => workflow_name }
+      params[ATTR_PROG] = PROG
       data = @http.get(instance_website_url(params))['data']
       data && @properties.object_from(
         data['name'],

--- a/lib/zenaton/client.rb
+++ b/lib/zenaton/client.rb
@@ -64,24 +64,34 @@ module Zenaton
 
     # Gets the url for the workers
     # @param resource [String] the endpoint for the worker
-    # @param params [Hash] query params to be url encoded
+    # @param params [Hash|String] query params to be url encoded
     # @return [String] the workers url with parameters
     def worker_url(resource = '', params = {})
       base_url = ENV['ZENATON_WORKER_URL'] || ZENATON_WORKER_URL
       port = ENV['ZENATON_WORKER_PORT'] || DEFAULT_WORKER_PORT
       url = "#{base_url}:#{port}/api/#{WORKER_API_VERSION}/#{resource}"
-      append_params_to_url(url, params)
+
+      if params.is_a?(Hash)
+        append_params_to_url(url, params)
+      else
+        add_app_env("#{url}?", params)
+      end
     end
 
     # Gets the url for zenaton api
     # @param resource [String] the endpoint for the api
-    # @param params [Hash] query params to be url encoded
+    # @param params [Hash|String] query params to be url encoded
     # @return [String] the api url with parameters
     def website_url(resource = '', params = {})
       api_url = ENV['ZENATON_API_URL'] || ZENATON_API_URL
       url = "#{api_url}/#{resource}"
-      params[API_TOKEN] = @api_token
-      append_params_to_url(url, params)
+
+      if params.is_a?(Hash)
+        params[API_TOKEN] = @api_token
+        append_params_to_url(url, params)
+      else
+        add_app_env("#{url}?#{API_TOKEN}=#{@api_token}&", params)
+      end
     end
 
     # Start a single task
@@ -170,6 +180,22 @@ module Zenaton
     end
 
     private
+
+    # DEPRECATED: This implementation does not safely encode the parameters to
+    # be passed as query params in a get request. This method gets called by
+    # agents up to version 0.4.5
+    def add_app_env(url, params)
+      deprecation_warning = <<~WARN
+        [WARNING] You are running a Zenaton agent with a version <= 0.4.5
+                  Please consider upgrading to a more recent version.
+      WARN
+      warn(deprecation_warning)
+
+      app_env = @app_env ? "#{APP_ENV}=#{@app_env}&" : ''
+      app_id = @app_id ? "#{APP_ID}=#{@app_id}&" : ''
+
+      "#{url}#{app_env}#{app_id}#{params}"
+    end
 
     def append_params_to_url(url, params)
       params[APP_ENV] = @app_env if @app_env

--- a/spec/zenaton/client_spec.rb
+++ b/spec/zenaton/client_spec.rb
@@ -72,11 +72,20 @@ RSpec.describe Zenaton::Client do
         ENV.delete('ZENATON_WORKER_PORT')
       end
 
-      it 'returns the worker url with params' do
+      it 'returns the worker url with hash params' do
         url = client.worker_url('my_resource', 'myParam' => 1)
         expect(url).to \
           eq('http://192.168.1.1:42/api/v_newton/my_resource?myParam=1')
       end
+
+      # rubocop:disable RSpec/MultipleExpectations
+      it 'returns the worker url with string params' do
+        expect do
+          url = client.worker_url('my_resource', 'myParam=1')
+          expect(url).to match(/myParam=1/)
+        end.to output(/WARNING/).to_stderr
+      end
+      # rubocop:enable RSpec/MultipleExpectations
     end
 
     context 'with environment and instances variables set' do
@@ -147,7 +156,16 @@ RSpec.describe Zenaton::Client do
           eq('http://192.168.1.1/my_resource?api_token=ApiToken&app_env=AppEnv&app_id=AppId')
       end
 
-      it 'encodes query params' do
+      # rubocop:disable RSpec/MultipleExpectations
+      it 'returns the worker url with string params' do
+        expect do
+          url = client.website_url('my_resource', 'param=1')
+          expect(url).to match(/param=1/)
+        end.to output(/WARNING/).to_stderr
+      end
+      # rubocop:enable RSpec/MultipleExpectations
+
+      it 'urlencodes hash params' do
         url = client.website_url('my_resource', 'this+that' => '@')
         expect(url).to match(/this%2Bthat=%40/)
       end

--- a/spec/zenaton/client_spec.rb
+++ b/spec/zenaton/client_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe Zenaton::Client do
       end
 
       it 'returns the worker url with params' do
-        url = client.worker_url('my_resource', 'myParam=1')
+        url = client.worker_url('my_resource', 'myParam' => 1)
         expect(url).to \
           eq('http://192.168.1.1:42/api/v_newton/my_resource?myParam=1')
       end
@@ -90,28 +90,43 @@ RSpec.describe Zenaton::Client do
         ENV.delete('ZENATON_WORKER_PORT')
       end
 
-      it 'returns the worker url with params and app env' do
-        url = client.worker_url('my_resource', 'myParam=1')
+      it 'returns the worker url with app env' do
+        url = client.worker_url('my_resource')
         expect(url).to \
-          eq('http://192.168.1.1:42/api/v_newton/my_resource?app_env=AppEnv&app_id=AppId&myParam=1')
+          eq('http://192.168.1.1:42/api/v_newton/my_resource?app_env=AppEnv&app_id=AppId')
+      end
+
+      it 'encodes query params' do
+        url = client.worker_url('my_resource', 'this+that' => '@')
+        expect(url).to match(/this%2Bthat=%40/)
       end
     end
 
     context 'with instances variables but no environment variables set' do
       before { described_class.init('AppId', 'ApiToken', 'AppEnv') }
 
-      it 'returns the default worker url with params and app env' do
-        url = client.worker_url('my_resource', 'myParam=1')
+      it 'returns the default worker url with app env' do
+        url = client.worker_url('my_resource')
         expect(url).to \
-          eq('http://localhost:4001/api/v_newton/my_resource?app_env=AppEnv&app_id=AppId&myParam=1')
+          eq('http://localhost:4001/api/v_newton/my_resource?app_env=AppEnv&app_id=AppId')
+      end
+
+      it 'encodes query params' do
+        url = client.worker_url('my_resource', 'this+that' => '@')
+        expect(url).to match(/this%2Bthat=%40/)
       end
     end
 
     context 'with no environment nor instances variables set' do
-      it 'returns the default worker url with params' do
-        url = client.worker_url('my_resource', 'myParam=1')
+      it 'returns the default worker url' do
+        url = client.worker_url('my_resource')
         expect(url).to \
-          eq('http://localhost:4001/api/v_newton/my_resource?myParam=1')
+          eq('http://localhost:4001/api/v_newton/my_resource?')
+      end
+
+      it 'encodes query params' do
+        url = client.worker_url('my_resource', 'this+that' => '@')
+        expect(url).to match(/this%2Bthat=%40/)
       end
     end
   end
@@ -126,18 +141,28 @@ RSpec.describe Zenaton::Client do
         ENV.delete('ZENATON_API_URL')
       end
 
-      it 'returns the website url with params and api token' do
-        url = client.website_url('my_resource', 'myParam=1')
+      it 'returns the website url with api token' do
+        url = client.website_url('my_resource')
         expect(url).to \
-          eq('http://192.168.1.1/my_resource?api_token=ApiToken&app_env=AppEnv&app_id=AppId&myParam=1')
+          eq('http://192.168.1.1/my_resource?api_token=ApiToken&app_env=AppEnv&app_id=AppId')
+      end
+
+      it 'encodes query params' do
+        url = client.website_url('my_resource', 'this+that' => '@')
+        expect(url).to match(/this%2Bthat=%40/)
       end
     end
 
     context 'with no environment variables set' do
-      it 'returns the default website url with params and api token' do
-        url = client.website_url('my_resource', 'myParam=1')
+      it 'returns the default website url api token' do
+        url = client.website_url('my_resource')
         expect(url).to \
-          eq('https://api.zenaton.com/api/v1/my_resource?api_token=ApiToken&app_env=AppEnv&app_id=AppId&myParam=1')
+          eq('https://api.zenaton.com/api/v1/my_resource?api_token=ApiToken&app_env=AppEnv&app_id=AppId')
+      end
+
+      it 'encodes query params' do
+        url = client.website_url('my_resource', 'this+that' => '@')
+        expect(url).to match(/this%2Bthat=%40/)
       end
     end
   end
@@ -301,7 +326,7 @@ RSpec.describe Zenaton::Client do
 
   describe '#find_workflow' do
     let(:expected_url) do
-      'https://api.zenaton.com/api/v1/instances?api_token=ApiToken&custom_id=MyCustomId&name=FakeWorkflow1&programming_language=Ruby'
+      'https://api.zenaton.com/api/v1/instances?custom_id=MyCustomId&name=FakeWorkflow1&programming_language=Ruby&api_token=ApiToken'
     end
     let(:result) do
       client.find_workflow('FakeWorkflow1', 'MyCustomId')


### PR DESCRIPTION
There was an issue where a workflow which used an email address as an ID
could not be stopped. This was caused by the custom id not being properly
encoded. This changes how params are passed to the client. We now use a
hash and leverage the `URI` module to ensure the hash is correctly
encoded into query params when needed.

To finish the fix, I will make update the agent to handle the different behaviour
based on this gem version.