### PR TITLE
Fix for waiting for the 31st

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   of hours if you create a wait task with `.monday(1).at("15")`. Otherwise the
   previous behaviour of waiting for next week is preserved.
 - Fix encoding of query parameters when searching for existing workflows
+- Now waiting for the 31st should wait for the next occurrence of the 31st even
+  if the current month does not have 31 days.
 
 ## [0.3.1] - 2018-10-02
 ### Fixed

--- a/lib/zenaton/traits/with_timestamp.rb
+++ b/lib/zenaton/traits/with_timestamp.rb
@@ -100,7 +100,7 @@ module Zenaton
 
       def _day_of_month(day, now, now_dup)
         _set_mode(MODE_MONTH_DAY)
-        now_dup = now_dup.change(day: day)
+        now_dup += 1.day until now_dup.mday == day
         now_dup += 1.month if now >= now_dup && !later_today?(now, day)
         now_dup
       end

--- a/spec/shared_examples/with_timestamp.rb
+++ b/spec/shared_examples/with_timestamp.rb
@@ -330,7 +330,7 @@ RSpec.shared_examples 'WithTimestamp' do |*initial_args|
     end
   end
 
-  context 'when today is Monday the 3rd of December 2012, at 11am' do
+  context 'when today is Monday the 3rd of December 2018, at 11am' do
     let(:today) { Time.utc(2018, 12, 3, 11, 0, 0) }
     let(:timestamp) { with_timestamp._get_timestamp_or_duration.first }
 
@@ -394,6 +394,82 @@ RSpec.shared_examples 'WithTimestamp' do |*initial_args|
       before { with_timestamp.day_of_month(3).at('9') }
 
       it 'waits until next month' do
+        expect(timestamp).to eq(expected_time.to_i)
+      end
+    end
+  end
+
+  describe '#day_of_month(31)' do
+    let(:timestamp) { with_timestamp._get_timestamp_or_duration.first }
+
+    before do
+      Timecop.freeze(today)
+      with_timestamp.day_of_month(31)
+    end
+
+    after { Timecop.return }
+
+    context 'when today is 03/02/19' do
+      let(:today) { Time.utc(2019, 2, 3, 11, 0, 0) }
+      let(:expected_time) { Time.utc(2019, 3, 31, 11, 0, 0) }
+
+      it 'waits until the 31st of March' do
+        expect(timestamp).to eq(expected_time.to_i)
+      end
+    end
+
+    context 'when today is 03/03/19' do
+      let(:today) { Time.utc(2019, 3, 3, 11, 0, 0) }
+      let(:expected_time) { Time.utc(2019, 3, 31, 11, 0, 0) }
+
+      it 'waits until the 31st of March' do
+        expect(timestamp).to eq(expected_time.to_i)
+      end
+    end
+
+    context 'when today is 03/04/19' do
+      let(:today) { Time.utc(2019, 4, 3, 11, 0, 0) }
+      let(:expected_time) { Time.utc(2019, 5, 31, 11, 0, 0) }
+
+      it 'waits until the 31st of May' do
+        expect(timestamp).to eq(expected_time.to_i)
+      end
+    end
+  end
+
+  describe '#day_of_month(30)' do
+    let(:timestamp) { with_timestamp._get_timestamp_or_duration.first }
+
+    before do
+      Timecop.freeze(today)
+      with_timestamp.day_of_month(30)
+    end
+
+    after { Timecop.return }
+
+    context 'when today is 03/02/19' do
+      let(:today) { Time.utc(2019, 2, 3, 11, 0, 0) }
+      let(:expected_time) { Time.utc(2019, 3, 30, 11, 0, 0) }
+
+      it 'waits until the 30th of March' do
+        expect(timestamp).to eq(expected_time.to_i)
+      end
+    end
+
+    context 'when today is 03/03/19' do
+      let(:today) { Time.utc(2019, 3, 3, 11, 0, 0) }
+      let(:expected_time) { Time.utc(2019, 3, 30, 11, 0, 0) }
+
+      it 'waits until the 30th of March' do
+        expect(timestamp).to eq(expected_time.to_i)
+      end
+    end
+
+    context 'when today is 03/04/19' do
+      let(:today) { Time.utc(2019, 4, 3, 11, 0, 0) }
+      let(:expected_time) { Time.utc(2019, 4, 30, 11, 0, 0) }
+
+      it 'waits until the 30th of April' do
         expect(timestamp).to eq(expected_time.to_i)
       end
     end


### PR DESCRIPTION
Tagging other language library maintainers for feedback.

Now waiting for the 31st should wait for the next occurrence of the
31st even if the current month does not have 31 days. In that case, it
will wait for the next month that has 31 days.