### PR TITLE
Disable Lossless symbol serialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changes
+- Disables lossless JSON serialization of symbols
+
 ## [0.4.0] - 2019-03-25
 ### Added
 - Calling `#dispatch` on tasks now allows to process tasks asynchronously

--- a/lib/zenaton/services/properties.rb
+++ b/lib/zenaton/services/properties.rb
@@ -1,7 +1,13 @@
 # frozen_string_literal: true
 
 require 'singleton'
-require 'json/add/core'
+require 'json/add/date'
+require 'json/add/date_time'
+require 'json/add/exception'
+require 'json/add/range'
+require 'json/add/regexp'
+require 'json/add/struct'
+require 'json/add/time'
 require 'json/add/rational'
 require 'json/add/complex'
 require 'json/add/bigdecimal'
@@ -42,8 +48,6 @@ module Zenaton
           klass.instance
         elsif NUMERIC_INITIALIATION.include?(klass)
           Kernel.send(klass.to_s, 1, 1)
-        elsif klass == Symbol
-          :place_holder
         else
           klass.allocate
         end

--- a/lib/zenaton/services/serializer.rb
+++ b/lib/zenaton/services/serializer.rb
@@ -16,6 +16,17 @@ module Zenaton
       KEY_DATA = 'd' # JSON key for json compatibles types
       KEY_STORE = 's' # JSON key for deserialized complex object
 
+      # Classes of basic objects that can be converted directly into JSON
+      BASIC_TYPES = [
+        String,
+        Symbol,
+        Integer,
+        Float,
+        TrueClass,
+        FalseClass,
+        NilClass
+      ].freeze
+
       def initialize
         @properties = Properties.new
       end
@@ -57,12 +68,7 @@ module Zenaton
       private
 
       def basic_type?(data)
-        data.is_a?(String) \
-          || data.is_a?(Integer) \
-          || data.is_a?(Float) \
-          || data.is_a?(TrueClass) \
-          || data.is_a?(FalseClass) \
-          || data.nil?
+        data.class.ancestors.any? { |klass| BASIC_TYPES.include?(klass) }
       end
 
       def encode_value(value)

--- a/spec/zenaton/services/properties_spec.rb
+++ b/spec/zenaton/services/properties_spec.rb
@@ -103,7 +103,7 @@ RSpec.describe Zenaton::Services::Properties do
       let(:object) { :hello }
 
       it 'returns the symbols as a string' do
-        expect(result).to eq('s' => 'hello')
+        expect(result).to eq('hello')
       end
     end
 
@@ -227,15 +227,6 @@ RSpec.describe Zenaton::Services::Properties do
 
       it 'has the expected methods' do
         expect(setup_object.a).to eq(1)
-      end
-    end
-
-    context 'with symbols' do
-      let(:object_name) { 'Symbol' }
-      let(:props) { { 's' => 'hello' } }
-
-      it 'returns a symbol version of the string' do
-        expect(setup_object).to eq(:hello)
       end
     end
 

--- a/spec/zenaton/services/serializer_spec.rb
+++ b/spec/zenaton/services/serializer_spec.rb
@@ -19,6 +19,14 @@ RSpec.describe Zenaton::Services::Serializer do
       end
     end
 
+    context 'with a symbol' do
+      let(:data) { :foobar }
+
+      it 'represents the atom as a data' do
+        expect(parsed_json).to eq('d' => 'foobar', 's' => [])
+      end
+    end
+
     context 'with an integer' do
       let(:data) { 1 }
 


### PR DESCRIPTION
The Searchkick gem expects symbols to be serialized to strings when
converting a Hash into JSON. There is a chance that other libraries may
make a similiar assumption.

Closes #56 