### PR TITLE
Fix symbol json encoding breaking compatibility with some gems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+ ### Changes
+- Fix symbol json encoding breaking compatibility with some gems
+
 ## [0.4.0] - 2019-03-25
 ### Added
 - Calling `#dispatch` on tasks now allows to process tasks asynchronously

--- a/lib/zenaton/services/properties.rb
+++ b/lib/zenaton/services/properties.rb
@@ -1,7 +1,13 @@
 # frozen_string_literal: true
 
 require 'singleton'
-require 'json/add/core'
+require 'json/add/date'
+require 'json/add/date_time'
+require 'json/add/exception'
+require 'json/add/range'
+require 'json/add/regexp'
+require 'json/add/struct'
+require 'json/add/time'
 require 'json/add/rational'
 require 'json/add/complex'
 require 'json/add/bigdecimal'
@@ -97,14 +103,22 @@ module Zenaton
       end
 
       def from_complex_type(object)
-        JSON.parse(object.to_json).tap do |attributes|
-          attributes.delete('json_class')
+        if object.is_a?(Symbol)
+          { 's' => object.to_s }
+        else
+          JSON.parse(object.to_json).tap do |attributes|
+            attributes.delete('json_class')
+          end
         end
       end
 
       def set_complex_type(object, props)
-        props['json_class'] = object.class.name
-        JSON(props.to_json)
+        if object.is_a?(Symbol)
+          props['s'].to_sym
+        else
+          props['json_class'] = object.class.name
+          JSON(props.to_json)
+        end
       end
 
       def special_case?(object)

--- a/spec/zenaton/services/serializer_spec.rb
+++ b/spec/zenaton/services/serializer_spec.rb
@@ -19,6 +19,17 @@ RSpec.describe Zenaton::Services::Serializer do
       end
     end
 
+    context 'with a symbol' do
+      let(:data) { :foobar }
+
+      it 'represents the symbol as a data' do
+        expect(parsed_json).to eq(
+          'o' => '@zenaton#0',
+          's' => [{ 'n' => 'Symbol', 'p' => { 's' => 'foobar' } }]
+        )
+      end
+    end
+
     context 'with an integer' do
       let(:data) { 1 }
 
@@ -322,6 +333,19 @@ RSpec.describe Zenaton::Services::Serializer do
 
       it 'returns the string' do
         expect(decoded).to eq('e')
+      end
+    end
+
+    context 'with a symbol do' do
+      let(:json) do
+        {
+          'o' => '@zenaton#0',
+          's' => [{ 'n' => 'Symbol', 'p' => { 's' => 'foobar' } }]
+        }.to_json
+      end
+
+      it 'returns the symbol' do
+        expect(decoded).to eq(:foobar)
       end
     end
 


### PR DESCRIPTION
This PR fix https://github.com/ankane/searchkick/issues/1255

The cause of the bug was the use of `require 'json/add/symbol'` in zenaton-ruby that changed the JSON representation of symbol globally (for other gems too).

Example:
```
➜  ~ irb
irb(main):001:0> require 'json'
=> true
irb(main):002:0> JSON.dump :hello
=> "\"hello\""
irb(main):003:0>
irb(main):004:0> require 'json/add/symbol'
=> true
irb(main):005:0> JSON.dump :hello
=> "{\"json_class\":\"Symbol\",\"s\":\"hello\"}"
```