### PR TITLE
Add intent_id when dispatching workflows and tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
+- Added `intent_id` when dispatching workflows and tasks, sending events and
+  pausing/resuming/stoping workflows.
+
 ## [0.4.1] - 2019-06-04
  ### Changes
 - Fix symbol json encoding breaking compatibility with some gems

--- a/spec/zenaton/client_spec.rb
+++ b/spec/zenaton/client_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe Zenaton::Client do
   let(:event) { FakeEvent.new }
   let(:version) { FakeVersion.new(1, 2) }
   let(:workflow_data) { { 'name' => 'Zenaton::Interfaces::Workflow' } }
+  let(:uuid) { 'some-very-valid-uuid4' }
 
   before do
     setup_client
@@ -190,6 +191,7 @@ RSpec.describe Zenaton::Client do
     let(:expected_url) { 'http://localhost:4001/api/v_newton/tasks?' }
     let(:expected_hash) do
       {
+        'intent_id' => uuid,
         'programming_language' => 'Ruby',
         'name' => 'FakeTask3',
         'maxProcessingTime' => nil,
@@ -214,6 +216,7 @@ RSpec.describe Zenaton::Client do
     let(:expected_url) { 'http://localhost:4001/api/v_newton/instances?' }
     let(:expected_hash) do
       {
+        'intent_id' => uuid,
         'programming_language' => 'Ruby',
         'canonical_name' => nil,
         'name' => 'FakeWorkflow1',
@@ -291,6 +294,7 @@ RSpec.describe Zenaton::Client do
     end
     let(:expected_options) do
       {
+        'intent_id' => uuid,
         'programming_language' => 'Ruby',
         'name' => 'MyWorkflow',
         'mode' => 'kill'
@@ -310,6 +314,7 @@ RSpec.describe Zenaton::Client do
     end
     let(:expected_options) do
       {
+        'intent_id' => uuid,
         'programming_language' => 'Ruby',
         'name' => 'MyWorkflow',
         'mode' => 'pause'
@@ -329,6 +334,7 @@ RSpec.describe Zenaton::Client do
     end
     let(:expected_options) do
       {
+        'intent_id' => uuid,
         'programming_language' => 'Ruby',
         'name' => 'MyWorkflow',
         'mode' => 'run'
@@ -414,6 +420,7 @@ RSpec.describe Zenaton::Client do
     end
     let(:expected_options) do
       {
+        'intent_id' => uuid,
         'programming_language' => 'Ruby',
         'name' => 'MyWorkflow',
         'custom_id' => 'MyCustomId',
@@ -439,5 +446,6 @@ RSpec.describe Zenaton::Client do
   def setup_client
     Singleton.__init__(described_class)
     allow(Zenaton::Services::Http).to receive(:new).and_return(http)
+    allow(SecureRandom).to receive(:uuid).and_return(uuid)
   end
 end


### PR DESCRIPTION
Port of the https://github.com/zenaton/zenaton-php/pull/50 (PHP) to the Ruby library. Adds an `intent_id` to the parameters sent with most requests to track a users intent.