### PR TITLE
Fix bad class name encoding when as_json is overrided.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Added `intent_id` when dispatching workflows and tasks, sending events and
   pausing/resuming/stoping workflows.
 
+### Fixed
+- Fixed an error caused by a bad class name encoding when `as_json` is overrided (in rails for example).
+
 ## [0.4.1] - 2019-06-04
  ### Changes
 - Fix symbol json encoding breaking compatibility with some gems

--- a/lib/zenaton/query/builder.rb
+++ b/lib/zenaton/query/builder.rb
@@ -26,35 +26,35 @@ module Zenaton
       # Finds a workflow
       # @return [Zenaton::Interfaces::Workflow]
       def find
-        @client.find_workflow(@klass, @id)
+        @client.find_workflow(@klass.to_s, @id)
       end
 
       # Sends an event to a workflow
       # @param event [Zenaton::Interfaces::Event] the event to send
       # @return [Zenaton::Query::Builder] the current builder
       def send_event(event)
-        @client.send_event(@klass, @id, event)
+        @client.send_event(@klass.to_s, @id, event)
         self
       end
 
       # Stops a workflow
       # @return [Zenaton::Query::Builder] the current builder
       def kill
-        @client.kill_workflow(@klass, @id)
+        @client.kill_workflow(@klass.to_s, @id)
         self
       end
 
       # Pauses a workflow
       # @return [Zenaton::Query::Builder] the current builder
       def pause
-        @client.pause_workflow(@klass, @id)
+        @client.pause_workflow(@klass.to_s, @id)
         self
       end
 
       # Resumes a workflow
       # @return [Zenaton::Query::Builder] the current builder
       def resume
-        @client.resume_workflow(@klass, @id)
+        @client.resume_workflow(@klass.to_s, @id)
         self
       end
 

--- a/spec/zenaton/query/builder_spec.rb
+++ b/spec/zenaton/query/builder_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe Zenaton::Query::Builder do
       before do
         builder.where_id('MyId')
         allow(client).to receive(:find_workflow)
-          .with(FakeWorkflow1, 'MyId')
+          .with('FakeWorkflow1', 'MyId')
           .and_return(workflow)
       end
 
@@ -66,7 +66,7 @@ RSpec.describe Zenaton::Query::Builder do
     context 'without an id set' do
       before do
         allow(client).to receive(:find_workflow)
-          .with(FakeWorkflow1, nil)
+          .with('FakeWorkflow1', nil)
           .and_return(workflow)
       end
 
@@ -80,7 +80,7 @@ RSpec.describe Zenaton::Query::Builder do
     before do
       builder.where_id('MyId')
       allow(client).to receive(:send_event)
-        .with(FakeWorkflow1, 'MyId', event)
+        .with('FakeWorkflow1', 'MyId', event)
         .and_return(nil)
     end
 
@@ -98,7 +98,7 @@ RSpec.describe Zenaton::Query::Builder do
     before do
       builder.where_id('MyId')
       allow(client).to receive(:kill_workflow)
-        .with(FakeWorkflow1, 'MyId')
+        .with('FakeWorkflow1', 'MyId')
         .and_return(nil)
     end
 
@@ -116,7 +116,7 @@ RSpec.describe Zenaton::Query::Builder do
     before do
       builder.where_id('MyId')
       allow(client).to receive(:pause_workflow)
-        .with(FakeWorkflow1, 'MyId')
+        .with('FakeWorkflow1', 'MyId')
         .and_return(nil)
     end
 
@@ -134,7 +134,7 @@ RSpec.describe Zenaton::Query::Builder do
     before do
       builder.where_id('MyId')
       allow(client).to receive(:resume_workflow)
-        .with(FakeWorkflow1, 'MyId')
+        .with('FakeWorkflow1', 'MyId')
         .and_return(nil)
     end
 


### PR DESCRIPTION
Some gems like rails can override the json representation of an object instance: https://github.com/rails/rails/blob/2-3-stable/activerecord/lib/active_record/serializers/json_serializer.rb

This can cause some errors when requesting the agent.

Example:
**with plain ruby**
`puts WaitEventWorkflow.where_id(id).instance_variable_get(:@klass).to_json`
`>> "WaitEventWorkflow"`

**with rails**
`puts WaitEventWorkflow.where_id(id).instance_variable_get(:@klass).to_json`
`>> "{}"`

