### PR TITLE
Require json

### DIFF
--- a/lib/zenaton/services/http.rb
+++ b/lib/zenaton/services/http.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'json'
 require 'net/http'
 require 'zenaton/exceptions'
 

--- a/lib/zenaton/services/serializer.rb
+++ b/lib/zenaton/services/serializer.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'json'
 require 'zenaton/services/properties'
 
 module Zenaton


### PR DESCRIPTION
SimpleCov was requiring 'json' under the hood making tests pass when they should not.
Removing simplecov and running the tests files individually return a failure without the following changes.

Even after removing SimpleCov, running the test suite in its integrity (vs files individually) reported a success. I don't want to spend too much time looking into the test setup so I am submitting the fix without any test coverage. Sorry.