### PR TITLE
Fix docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
+- Added missing documentation for serialization
+
 ### Fixed
 
 ## [0.5.0] - 2019-08-27

--- a/lib/zenaton/refinements.rb
+++ b/lib/zenaton/refinements.rb
@@ -14,3 +14,9 @@ require 'zenaton/refinements/regexp'
 require 'zenaton/refinements/struct'
 require 'zenaton/refinements/symbol'
 require 'zenaton/refinements/time'
+
+module Zenaton
+  # Reimplements json encoding from `json/add` as refinements
+  module Refinements
+  end
+end

--- a/lib/zenaton/refinements/big_decimal.rb
+++ b/lib/zenaton/refinements/big_decimal.rb
@@ -5,9 +5,9 @@ defined?(::BigDecimal) or require 'bigdecimal'
 # rubocop:enable Style/AndOr
 
 module Zenaton
-  # :nodoc
   module Refinements
     refine BigDecimal do
+      # Convert to a simple hash
       def to_zenaton
         {
           'b' => _dump
@@ -19,6 +19,7 @@ end
 
 # Reimplements `json/add/bigdecimal`
 class BigDecimal
+  # Parse from simple hash
   def self.from_zenaton(props)
     BigDecimal._load props['b']
   end

--- a/lib/zenaton/refinements/big_decimal.rb
+++ b/lib/zenaton/refinements/big_decimal.rb
@@ -5,6 +5,7 @@ defined?(::BigDecimal) or require 'bigdecimal'
 # rubocop:enable Style/AndOr
 
 module Zenaton
+  # :nodoc
   module Refinements
     refine BigDecimal do
       # Convert to a simple hash

--- a/lib/zenaton/refinements/class.rb
+++ b/lib/zenaton/refinements/class.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 module Zenaton
+  # :nodoc
   module Refinements
     refine Class do
       # Convert to a simple hash

--- a/lib/zenaton/refinements/class.rb
+++ b/lib/zenaton/refinements/class.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
 module Zenaton
-  # :nodoc
   module Refinements
     refine Class do
+      # Convert to a simple hash
       def to_zenaton
         {
           'n' => name
@@ -15,6 +15,7 @@ end
 
 # Load an instance of class from zenaton properties
 class Class
+  # Parse from simple hash
   def self.from_zenaton(props)
     Object.const_get(props['n'])
   end

--- a/lib/zenaton/refinements/complex.rb
+++ b/lib/zenaton/refinements/complex.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 module Zenaton
+  # :nodoc
   module Refinements
     refine Complex do
       # Convert to a simple hash

--- a/lib/zenaton/refinements/complex.rb
+++ b/lib/zenaton/refinements/complex.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
 module Zenaton
-  # :nodoc
   module Refinements
     refine Complex do
+      # Convert to a simple hash
       def to_zenaton
         {
           'r' => real,
@@ -16,6 +16,7 @@ end
 
 # Reimplements `json/add/complex`
 class Complex
+  # Parse from simple hash
   def self.from_zenaton(props)
     Complex(props['r'], props['i'])
   end

--- a/lib/zenaton/refinements/date.rb
+++ b/lib/zenaton/refinements/date.rb
@@ -3,9 +3,9 @@
 require 'date'
 
 module Zenaton
-  # :nodoc
   module Refinements
     refine Date do
+      # Convert to a simple hash
       def to_zenaton
         {
           'y' => year,
@@ -20,6 +20,7 @@ end
 
 # Reimplements `json/add/date`
 class Date
+  # Parse from simple hash
   def self.from_zenaton(props)
     civil(*props.values_at('y', 'm', 'd', 'sg'))
   end

--- a/lib/zenaton/refinements/date.rb
+++ b/lib/zenaton/refinements/date.rb
@@ -3,6 +3,7 @@
 require 'date'
 
 module Zenaton
+  # :nodoc
   module Refinements
     refine Date do
       # Convert to a simple hash

--- a/lib/zenaton/refinements/date_time.rb
+++ b/lib/zenaton/refinements/date_time.rb
@@ -3,9 +3,9 @@
 require 'date'
 
 module Zenaton
-  # :nodoc
   module Refinements
     refine DateTime do
+      # Convert to a simple hash
       def to_zenaton
         {
           'y' => year,
@@ -24,6 +24,7 @@ end
 
 # Reimplements `json/add/date_time`
 class DateTime
+  # Parse from simple hash
   def self.from_zenaton(props)
     args = props.values_at('y', 'm', 'd', 'H', 'M', 'S')
     of_a, of_b = props['of'].split('/')

--- a/lib/zenaton/refinements/date_time.rb
+++ b/lib/zenaton/refinements/date_time.rb
@@ -3,6 +3,7 @@
 require 'date'
 
 module Zenaton
+  # :nodoc
   module Refinements
     refine DateTime do
       # Convert to a simple hash

--- a/lib/zenaton/refinements/exception.rb
+++ b/lib/zenaton/refinements/exception.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
 module Zenaton
-  # :nodoc
   module Refinements
     refine Exception do
+      # Convert to a simple hash
       def to_zenaton
         {
           'm' => message,
@@ -16,6 +16,7 @@ end
 
 # Reimplements `json/add/exception`
 class Exception
+  # Parse from simple hash
   def self.from_zenaton(props)
     result = new(props['m'])
     result.set_backtrace props['b']

--- a/lib/zenaton/refinements/exception.rb
+++ b/lib/zenaton/refinements/exception.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 module Zenaton
+  # :nodoc
   module Refinements
     refine Exception do
       # Convert to a simple hash

--- a/lib/zenaton/refinements/object.rb
+++ b/lib/zenaton/refinements/object.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 module Zenaton
+  # :nodoc
   module Refinements
     refine Object do
       # Convert to a simple hash

--- a/lib/zenaton/refinements/object.rb
+++ b/lib/zenaton/refinements/object.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
 module Zenaton
-  # :nodoc
   module Refinements
     refine Object do
+      # Convert to a simple hash
       def to_zenaton
         instance_variables.map do |ivar|
           value = instance_variable_get(ivar)

--- a/lib/zenaton/refinements/open_struct.rb
+++ b/lib/zenaton/refinements/open_struct.rb
@@ -3,6 +3,7 @@
 require 'ostruct'
 
 module Zenaton
+  # :nodoc
   module Refinements
     refine OpenStruct do
       # Convert to a simple hash

--- a/lib/zenaton/refinements/open_struct.rb
+++ b/lib/zenaton/refinements/open_struct.rb
@@ -3,9 +3,9 @@
 require 'ostruct'
 
 module Zenaton
-  # :nodoc
   module Refinements
     refine OpenStruct do
+      # Convert to a simple hash
       def to_zenaton
         class_name = self.class.name.to_s
         error_message = 'Only named structs are supported'
@@ -20,6 +20,7 @@ end
 
 # Reimplements `json/add/ostruct`
 class OpenStruct
+  # Parse from simple hash
   def self.from_zenaton(props)
     new(props['t'] || props[:t])
   end

--- a/lib/zenaton/refinements/range.rb
+++ b/lib/zenaton/refinements/range.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 module Zenaton
+  # :nodoc
   module Refinements
     refine Range do
       # Convert to a simple hash

--- a/lib/zenaton/refinements/range.rb
+++ b/lib/zenaton/refinements/range.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
 module Zenaton
-  # :nodoc
   module Refinements
     refine Range do
+      # Convert to a simple hash
       def to_zenaton
         {
           'a' => [first, last, exclude_end?]
@@ -15,6 +15,7 @@ end
 
 # Reimplements `json/add/range`
 class Range
+  # Parse from simple hash
   def self.from_zenaton(props)
     new(*props['a'])
   end

--- a/lib/zenaton/refinements/rational.rb
+++ b/lib/zenaton/refinements/rational.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
 module Zenaton
-  # :nodoc
   module Refinements
     refine Rational do
+      # Convert to a simple hash
       def to_zenaton
         {
           'n' => numerator,
@@ -16,6 +16,7 @@ end
 
 # Reimplements `json/add/rational`
 class Rational
+  # Parse from simple hash
   def self.from_zenaton(props)
     Rational(props['n'], props['d'])
   end

--- a/lib/zenaton/refinements/rational.rb
+++ b/lib/zenaton/refinements/rational.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 module Zenaton
+  # :nodoc
   module Refinements
     refine Rational do
       # Convert to a simple hash

--- a/lib/zenaton/refinements/regexp.rb
+++ b/lib/zenaton/refinements/regexp.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 module Zenaton
+  # :nodoc
   module Refinements
     refine Regexp do
       # Convert to a simple hash

--- a/lib/zenaton/refinements/regexp.rb
+++ b/lib/zenaton/refinements/regexp.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
 module Zenaton
-  # :nodoc
   module Refinements
     refine Regexp do
+      # Convert to a simple hash
       def to_zenaton
         {
           'o' => options,
@@ -16,6 +16,7 @@ end
 
 # Reimplements `json/add/regexp`
 class Regexp
+  # Parse from simple hash
   def self.from_zenaton(props)
     new(props['s'], props['o'])
   end

--- a/lib/zenaton/refinements/struct.rb
+++ b/lib/zenaton/refinements/struct.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
 module Zenaton
-  # :nodoc
   module Refinements
     refine Struct do
+      # Convert to a simple hash
       def to_zenaton
         class_name = self.class.name.to_s
         error_message = 'Only named structs are supported'
@@ -18,6 +18,7 @@ end
 
 # Reimplements `json/add/struct`
 class Struct
+  # Parse from simple hash
   def self.from_zenaton(props)
     new(*props['v'])
   end

--- a/lib/zenaton/refinements/struct.rb
+++ b/lib/zenaton/refinements/struct.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 module Zenaton
+  # :nodoc
   module Refinements
     refine Struct do
       # Convert to a simple hash

--- a/lib/zenaton/refinements/symbol.rb
+++ b/lib/zenaton/refinements/symbol.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
 module Zenaton
-  # :nodoc
   module Refinements
     refine Symbol do
+      # Convert to a simple hash
       def to_zenaton
         {
           's' => to_s
@@ -15,6 +15,7 @@ end
 
 # Reimplements `json/add/symbol`
 class Symbol
+  # Parse from simple hash
   def self.from_zenaton(props)
     props['s'].to_sym
   end

--- a/lib/zenaton/refinements/symbol.rb
+++ b/lib/zenaton/refinements/symbol.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 module Zenaton
+  # :nodoc
   module Refinements
     refine Symbol do
       # Convert to a simple hash

--- a/lib/zenaton/refinements/time.rb
+++ b/lib/zenaton/refinements/time.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 module Zenaton
+  # :nodoc
   module Refinements
     refine Time do
       # Convert to a simple hash

--- a/lib/zenaton/refinements/time.rb
+++ b/lib/zenaton/refinements/time.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
 module Zenaton
-  # :nodoc
   module Refinements
     refine Time do
+      # Convert to a simple hash
       def to_zenaton
         nanoseconds = [tv_usec * 1000]
         respond_to?(:tv_nsec) && nanoseconds << tv_nsec
@@ -19,6 +19,7 @@ end
 
 # Reimplements `json/add/time`
 class Time
+  # Parse from simple hash
   def self.from_zenaton(props)
     if (usec = props.delete('u')) # used to be tv_usec -> tv_nsec
       props['n'] = usec * 1000

--- a/lib/zenaton/traits/with_timestamp.rb
+++ b/lib/zenaton/traits/with_timestamp.rb
@@ -24,7 +24,7 @@ module Zenaton
       end
 
       # Calculates the timestamp based on either timestamp or duration methods
-      # @return Array<Integer, NilClass>
+      # @return [Array<Integer, NilClass>]
       def _get_timestamp_or_duration
         return [nil, nil] unless @buffer
 


### PR DESCRIPTION
Adds missing documentation and fixes one invalid typespec in `with_timestamp.rb`. The remainning missing documentation and errors have to do with the new graphql part. Planning to address that after #85 lands to avoid git conlicts.

Running `yard doc` after this commit:
```
[warn]: @param tag has unknown parameter name: body 
    in file `lib/zenaton/services/graphql.rb' near line 41
Files:          38
Modules:        12 (    0 undocumented)
Classes:        37 (    0 undocumented)
Constants:      41 (    2 undocumented)
Attributes:      7 (    0 undocumented)
Methods:        77 (    5 undocumented)
 95.98% documented
```

Closes #80 