### PR TITLE
Decoded hashes are now instances of HashWithIndifferentAccess

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - Added support to activesupport 6.0.0.
 
-### Fixed
+### Changed
+- Decoded hashes are now instances of `ActiveSupport::HashWithIndifferentAccess`
 
 ## [0.5.2] - 2019-09-19
 

--- a/lib/zenaton/services/serializer.rb
+++ b/lib/zenaton/services/serializer.rb
@@ -2,7 +2,7 @@
 
 require 'json'
 require 'zenaton/services/properties'
-require 'json'
+require 'active_support/core_ext/hash/indifferent_access.rb'
 
 module Zenaton
   module Services
@@ -169,7 +169,7 @@ module Zenaton
       end
 
       def decode_hash(id, hash)
-        @decoded[id] = {}
+        @decoded[id] = ActiveSupport::HashWithIndifferentAccess.new
         hash.each do |key, value|
           @decoded[id][key] = decode_element(value)
         end

--- a/spec/zenaton/services/serializer_spec.rb
+++ b/spec/zenaton/services/serializer_spec.rb
@@ -586,6 +586,10 @@ RSpec.describe Zenaton::Services::Serializer do
       it 'has correct circular structure' do
         expect(decoded['child']['parent']).to eq(decoded)
       end
+
+      it 'has indifferent access' do
+        expect(decoded[:child][:parent]).to eq(decoded['child']['parent'])
+      end
     end
 
     context 'with empty circular hashes' do


### PR DESCRIPTION
Closes #91 by using [`ActiveSupport::HashWithIndifferentAccess`](https://api.rubyonrails.org/classes/ActiveSupport/HashWithIndifferentAccess.html) for decoding hashes